### PR TITLE
[TEAM15-214] chore(entity): 엔티티의 일반적인 컬럼을 자동으로 관리하는 BaseEntity와 BaseGeneralEntity 클래스 추가 (Common 모듈)

### DIFF
--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/adapter/out/persistence/audit/BaseEntity.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/adapter/out/persistence/audit/BaseEntity.java
@@ -1,0 +1,31 @@
+package com.greenbowl.greenbowlserver.common.adapter.out.persistence.audit;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@EntityListeners(value = AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime modifiedAt;
+}

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/adapter/out/persistence/audit/BaseGeneralEntity.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/adapter/out/persistence/audit/BaseGeneralEntity.java
@@ -1,0 +1,30 @@
+package com.greenbowl.greenbowlserver.common.adapter.out.persistence.audit;
+
+import lombok.Getter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+
+import static com.greenbowl.greenbowlserver.common.utility.EntityConstant.BOOLEAN_DEFAULT_FALSE;
+import static javax.persistence.GenerationType.IDENTITY;
+
+
+@EntityListeners(value = AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseGeneralEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, columnDefinition = BOOLEAN_DEFAULT_FALSE)
+    private boolean deleteYn;
+
+    protected void deleteEntity() {
+        deleteYn = true;
+    }
+
+    protected void undeleteEntity() {
+        deleteYn = false;
+    }
+}

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/configuration/AuditConfig.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/configuration/AuditConfig.java
@@ -1,0 +1,9 @@
+package com.greenbowl.greenbowlserver.common.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class AuditConfig {
+}

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/utility/EntityConstant.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/utility/EntityConstant.java
@@ -1,0 +1,5 @@
+package com.greenbowl.greenbowlserver.common.utility;
+
+public class EntityConstant {
+    public static final String BOOLEAN_DEFAULT_FALSE = "boolean default false";
+}


### PR DESCRIPTION
## resolve [TEAM15-214](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/milestones/rfL9HTjN8EQ3qehc8x9nQ)
## resolve #11

## 작업내용
- AuditConfig 클래스

### BaseEntity 클래스
- CreatedAt 속성
- ModifiedAt 속성

### BaseGeneralEntity 클래스
- ID 속성
- deleteYn 속성