### PR TITLE
[TEAM15-220] chore(format): 포맷 검증과 변환을 위한 유틸리티 클래스 추가 (Common 모듈)

### DIFF
--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/adapter/in/InputFormatValidator.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/adapter/in/InputFormatValidator.java
@@ -1,0 +1,25 @@
+package com.greenbowl.greenbowlserver.common.adapter.in;
+
+import static com.greenbowl.greenbowlserver.common.utility.RegularExpressionConstant.POSITIVE_INTEGER_PATTERN;
+
+public class InputFormatValidator {
+    static final String ID_NO_VALUE_EXCEPTION = "ID는 필수값입니다.";
+    static final String INVALID_ID_EXCEPTION = "ID는 양의 정수(1 이상의 숫자값)여야 합니다. 입력된 ID: ";
+
+    public static void validateId(String id) {
+        checkIdIsNotBlank(id);
+        checkIdPattern(id);
+    }
+
+    private static void checkIdIsNotBlank(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException(ID_NO_VALUE_EXCEPTION);
+        }
+    }
+
+    private static void checkIdPattern(String id) {
+        if (!id.matches(POSITIVE_INTEGER_PATTERN)) {
+            throw new IllegalArgumentException(INVALID_ID_EXCEPTION + id);
+        }
+    }
+}

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/TargetType.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/TargetType.java
@@ -1,0 +1,12 @@
+package com.greenbowl.greenbowlserver.common.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum TargetType {
+    RECIPE_IMAGE("레시피 이미지");
+
+    private final String description;
+}

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/ErrorResponse.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption;
+package com.greenbowl.greenbowlserver.common.domain.excpeption;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/ExceptionMessage.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/ExceptionMessage.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption;
+package com.greenbowl.greenbowlserver.common.domain.excpeption;
 
 public class ExceptionMessage {
     public static final String PARSING_LONG_EXCEPTION_MESSAGE
@@ -19,6 +19,10 @@ public class ExceptionMessage {
             = "시간값만 LocalDateTime 타입으로 변환할 수 있습니다. 현재 변환 대상 값: %s";
     public static final String INVALID_TARGET_TYPE_EXCEPTION_MESSAGE
             = "존재하는 도메인만 TargetType으로 변환할 수 있습니다. 현재 변환 대상 값: %s";
+
+    public static final String EMAIL_NO_VALUE_EXCEPTION_MESSAGE = "이메일 주소는 필수값입니다.";
+    public static final String INVALID_EMAIL_EXCEPTION_MESSAGE
+            = "이메일 주소 형식이 잘못되었습니다. 예: abcd@abc.com\n전송된 이메일 주소: %s";
 
     public static final String ID_NO_VALUE_EXCEPTION_MESSAGE = "ID는 필수값입니다.";
     public static final String INVALID_ID_EXCEPTION_MESSAGE = "ID는 양의 정수(1 이상의 숫자값)여야 합니다. 전송된 ID: %s";

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption;
+package com.greenbowl.greenbowlserver.common.domain.excpeption;
 
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/invalidvalue/InvalidEmailException.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/invalidvalue/InvalidEmailException.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption.illegalargument.invalidvalue;
+package com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.invalidvalue;
 
 public class InvalidEmailException extends InvalidValueException {
     public InvalidEmailException(String message) {

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/invalidvalue/InvalidIdException.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/invalidvalue/InvalidIdException.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption.illegalargument.invalidvalue;
+package com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.invalidvalue;
 
 public class InvalidIdException extends InvalidValueException {
     public InvalidIdException(String message) {

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/invalidvalue/InvalidTargetTypeException.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/invalidvalue/InvalidTargetTypeException.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption.illegalargument.invalidvalue;
+package com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.invalidvalue;
 
 public class InvalidTargetTypeException extends InvalidValueException {
     public InvalidTargetTypeException(String message) {

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/invalidvalue/InvalidValueException.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/invalidvalue/InvalidValueException.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption.illegalargument.invalidvalue;
+package com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.invalidvalue;
 
 public abstract class InvalidValueException extends IllegalArgumentException {
     public InvalidValueException(String message) {

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/invalidvalue/ParsingBooleanException.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/invalidvalue/ParsingBooleanException.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption.illegalargument.invalidvalue;
+package com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.invalidvalue;
 
 public class ParsingBooleanException extends InvalidValueException {
     public ParsingBooleanException(String message) {

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/invalidvalue/ParsingLocalDateTimeException.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/invalidvalue/ParsingLocalDateTimeException.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption.illegalargument.invalidvalue;
+package com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.invalidvalue;
 
 public class ParsingLocalDateTimeException extends InvalidValueException {
     public ParsingLocalDateTimeException(String message) {

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/novalue/EmailNoValueException.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/novalue/EmailNoValueException.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption.illegalargument.novalue;
+package com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.novalue;
 
 public class EmailNoValueException extends NoValueException {
     public EmailNoValueException(String message) {

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/novalue/IdNoValueException.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/novalue/IdNoValueException.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption.illegalargument.novalue;
+package com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.novalue;
 
 public class IdNoValueException extends NoValueException {
     public IdNoValueException(String message) {

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/novalue/NoValueException.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/novalue/NoValueException.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption.illegalargument.novalue;
+package com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.novalue;
 
 public abstract class NoValueException extends IllegalArgumentException {
     public NoValueException(String message) {

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/numberformat/ParsingByteException.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/numberformat/ParsingByteException.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption.illegalargument.numberformat;
+package com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.numberformat;
 
 public class ParsingByteException extends NumberFormatException {
     public ParsingByteException(String message) {

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/numberformat/ParsingDoubleException.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/numberformat/ParsingDoubleException.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption.illegalargument.numberformat;
+package com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.numberformat;
 
 public class ParsingDoubleException extends NumberFormatException {
     public ParsingDoubleException(String message) {

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/numberformat/ParsingFloatException.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/numberformat/ParsingFloatException.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption.illegalargument.numberformat;
+package com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.numberformat;
 
 public class ParsingFloatException extends NumberFormatException {
     public ParsingFloatException(String message) {

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/numberformat/ParsingIntegerException.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/numberformat/ParsingIntegerException.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption.illegalargument.numberformat;
+package com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.numberformat;
 
 public class ParsingIntegerException extends NumberFormatException {
     public ParsingIntegerException(String message) {

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/numberformat/ParsingLongException.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/numberformat/ParsingLongException.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption.illegalargument.numberformat;
+package com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.numberformat;
 
 public class ParsingLongException extends NumberFormatException {
     public ParsingLongException(String message) {

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/numberformat/ParsingShortException.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/domain/excpeption/illegalargument/numberformat/ParsingShortException.java
@@ -1,4 +1,4 @@
-package com.greenbowl.greenbowlserver.common.excpeption.illegalargument.numberformat;
+package com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.numberformat;
 
 public class ParsingShortException extends NumberFormatException {
     public ParsingShortException(String message) {

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/utility/FormatConverter.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/utility/FormatConverter.java
@@ -1,0 +1,82 @@
+package com.greenbowl.greenbowlserver.common.utility;
+
+import com.greenbowl.greenbowlserver.common.domain.TargetType;
+import com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.invalidvalue.InvalidTargetTypeException;
+import com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.invalidvalue.ParsingBooleanException;
+import com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.numberformat.*;
+
+import static com.greenbowl.greenbowlserver.common.domain.excpeption.ExceptionMessage.*;
+
+public class FormatConverter {
+    private static final String TRUE = "true";
+    private static final String FALSE = "false";
+
+    public static Long parseToLong(String number) {
+        try {
+            return Long.parseLong(number);
+        } catch (NumberFormatException nfe) {
+            throw new ParsingLongException((String.format(PARSING_LONG_EXCEPTION_MESSAGE, number)));
+        }
+    }
+
+    public static Integer parseToInteger(String number) {
+        try {
+            return Integer.parseInt(number);
+        } catch (NumberFormatException nfe) {
+            throw new ParsingIntegerException((String.format(PARSING_INTEGER_EXCEPTION_MESSAGE, number)));
+        }
+    }
+
+    public static Short parseToShort(String number) throws ParsingShortException {
+        try {
+            return Short.parseShort(number);
+        } catch (NumberFormatException nfe) {
+            throw new ParsingShortException((String.format(PARSING_SHORT_EXCEPTION_MESSAGE, number)));
+        }
+    }
+
+    public static Byte parseToByte(String number) throws ParsingByteException {
+        try {
+            return Byte.parseByte(number);
+        } catch (NumberFormatException nfe) {
+            throw new ParsingByteException((String.format(PARSING_BYTE_EXCEPTION_MESSAGE, number)));
+        }
+    }
+
+    public static Double parseToDouble(String primeNumber) {
+        try {
+            return Double.parseDouble(primeNumber);
+        } catch (NumberFormatException nfe) {
+            throw new ParsingDoubleException((String.format(PARSING_DOUBLE_EXCEPTION_MESSAGE, primeNumber)));
+        }
+    }
+
+    public static Float parseToFloat(String primeNumber) {
+        try {
+            return Float.parseFloat(primeNumber);
+        } catch (NumberFormatException nfe) {
+            throw new ParsingFloatException((String.format(PARSING_FLOAT_EXCEPTION_MESSAGE, primeNumber)));
+        }
+    }
+
+    public static boolean parseToBoolean(String value) {
+        if (!value.equals(TRUE) && !value.equals(FALSE)) {
+            throw new ParsingBooleanException((String.format(PARSING_BOOLEAN_EXCEPTION_MESSAGE, value)));
+        }
+
+        return Boolean.parseBoolean(value);
+    }
+
+    public static TargetType parseToTargetType(String targetType) {
+        try {
+            return TargetType.valueOf(targetType);
+        } catch (IllegalArgumentException iae) {
+            throw new InvalidTargetTypeException(String.format(INVALID_TARGET_TYPE_EXCEPTION_MESSAGE, targetType));
+        }
+    }
+
+    public static String sanitizeFileName(String filename) {
+        return filename.replaceAll("\\s+", "-")
+                .replaceAll("[^a-zA-Z0-9._-]", "");
+    }
+}

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/utility/FormatValidator.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/utility/FormatValidator.java
@@ -1,0 +1,49 @@
+package com.greenbowl.greenbowlserver.common.utility;
+
+
+import com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.invalidvalue.InvalidEmailException;
+import com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.invalidvalue.InvalidIdException;
+import com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.novalue.EmailNoValueException;
+import com.greenbowl.greenbowlserver.common.domain.excpeption.illegalargument.novalue.IdNoValueException;
+
+import java.util.List;
+
+import static com.greenbowl.greenbowlserver.common.domain.excpeption.ExceptionMessage.*;
+import static com.greenbowl.greenbowlserver.common.utility.RegularExpressionConstant.EMAIL_PATTERN;
+import static com.greenbowl.greenbowlserver.common.utility.RegularExpressionConstant.POSITIVE_INTEGER_PATTERN;
+
+public class FormatValidator {
+    public static void validateEmail(String email) {
+        if (!hasValue(email)) {
+            throw new EmailNoValueException(EMAIL_NO_VALUE_EXCEPTION_MESSAGE);
+        }
+        if (!isValid(email, EMAIL_PATTERN)) {
+            throw new InvalidEmailException(String.format(INVALID_EMAIL_EXCEPTION_MESSAGE + email));
+        }
+    }
+
+    public static void validateId(String id) {
+        if (!hasValue(id)) {
+            throw new IdNoValueException(ID_NO_VALUE_EXCEPTION_MESSAGE);
+        }
+        if (!isValid(id, POSITIVE_INTEGER_PATTERN)) {
+            throw new InvalidIdException(String.format(INVALID_ID_EXCEPTION_MESSAGE, id));
+        }
+    }
+
+    public static boolean hasValue(Object value) {
+        return value != null;
+    }
+
+    public static boolean hasValue(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    public static boolean hasValue(List value) {
+        return value != null && !value.isEmpty();
+    }
+
+    private static boolean isValid(String value, String pattern) {
+        return value.matches(pattern);
+    }
+}

--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/utility/RegularExpressionConstant.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/utility/RegularExpressionConstant.java
@@ -1,0 +1,6 @@
+package com.greenbowl.greenbowlserver.common.utility;
+
+public class RegularExpressionConstant {
+    public static final String EMAIL_PATTERN = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+    public static final String POSITIVE_INTEGER_PATTERN = "^([1-9]\\d*)$";
+}

--- a/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/configuration/CommonConfig.java
+++ b/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/configuration/CommonConfig.java
@@ -1,7 +1,7 @@
 package com.greenbowl.greenbowlserver.recommendation.configuration;
 
 import com.greenbowl.greenbowlserver.common.application.aop.LoggingAspect;
-import com.greenbowl.greenbowlserver.common.excpeption.GlobalExceptionHandler;
+import com.greenbowl.greenbowlserver.common.domain.excpeption.GlobalExceptionHandler;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 


### PR DESCRIPTION
## resolve [TEAM15-220](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/milestones/_Kj3_YMFq2AY5cnTtHam8)
## resolve #13

## 작업내용
- 정규표현식 상수 추가
- 대상 타입을 포함하는 TargetType 추가
- 예외 관련 패키지를 domain 패키지 하위로 이동

### FormatValidator
- 이메일 주소 유효성 검사
- ID 유효성 검사
- 객체, 문자열, 리스트의 값 존재 여부 검사
- 임의의 패턴에 대한 범용 문자열 포맷 검사

### FormatConverter
- 각종 숫자 포맷 변환 (Long, Integer, Short, Byte, Double, Float)
- 논리 타입 포맷 변환
- TargetType 포맷 변환