### PR TITLE
[TEAM15-312] fix(audit): 다른 서비스에서 Common 모듈의 Audit 기능을 적용할 수 없는 문제 해결

### DIFF
--- a/common/src/main/resources/META-INF/spring.factories
+++ b/common/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.greenbowl.greenbowlserver.common.configuration.InterceptorConfig
+com.greenbowl.greenbowlserver.common.configuration.InterceptorConfig,\
+com.greenbowl.greenbowlserver.common.configuration.AuditConfig


### PR DESCRIPTION
## resolve [TEAM15-312](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/milestones/O2Q-cvHLxNA2Q76RIDOz9)
## resolve #22

## 작업내용
- Common 모듈의 spring.factories 설정 파일에 AuditConfig 클래스 추가

## 배포
- [x] 성공
- [ ] 실패