### PR TITLE
[TEAM15-483] chore(cors): 레시피 서비스 CORS 활성화

### DIFF
--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/configuration/WebConfig.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/configuration/WebConfig.java
@@ -1,0 +1,21 @@
+package com.greenbowl.greenbowlserver.recipe.adapter.in.web.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Value("${frontend.url}")
+    private String frontendUrl;
+
+    @Override
+    public void addCorsMappings(CorsRegistry corsRegistry) {
+        corsRegistry.addMapping("/**")
+                .allowedOriginPatterns(frontendUrl)
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(false);
+    }
+}

--- a/recipe-service/recipe-adapters/src/main/resources/application.yml
+++ b/recipe-service/recipe-adapters/src/main/resources/application.yml
@@ -27,5 +27,7 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER
+frontend:
+  url: ${GREENBOWL_FRONTEND_URL}
 logging:
   config: classpath:logback-spring.xml


### PR DESCRIPTION
## resolve [TEAM15-483](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/milestones/WvF_c4g548b1BR9DQGGo4)
## resolve #59

## 작업내용
- CORS 설정 클래스(WebConfig) 추가
- 애플리케이션 설정(application.yml)에 FRONTEND_URL 환경 변수 추가
- 프론트엔드 URL에 대한 CORS 활성화
- HTTP 메서드
    - GET
    - POST
    - PUT
    - PATCH
    - DELETE
    - HEAD
    - OPTIONS

## 배포
- [x] 성공
- [ ] 실패