### PR TITLE
[TEAM15-448] feat(recipe): 클라이언트는 레시피 서버를 통해 요청한 레시피 정보를 저장할 수 있다

### DIFF
--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/controller/AddBookmarkRecipeController.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/controller/AddBookmarkRecipeController.java
@@ -1,0 +1,30 @@
+package com.greenbowl.greenbowlserver.recipe.adapter.in.web.controller;
+
+import com.greenbowl.greenbowlserver.common.adapter.in.WebAdapter;
+import com.greenbowl.greenbowlserver.recipe.adapter.in.web.mapper.RecipeRequestToCommandMapper;
+import com.greenbowl.greenbowlserver.recipe.adapter.in.web.request.AddRecipeRequest;
+import com.greenbowl.greenbowlserver.recipe.port.in.usecase.CreateRecipeUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class AddBookmarkRecipeController {
+    private final CreateRecipeUseCase createRecipeUseCase;
+
+    @PostMapping()
+    public ResponseEntity<Void> addRecipe(@RequestBody AddRecipeRequest addRecipeRequest) {
+        // TODO: 회원 기능 구현 후 JWT Payload 디코딩을 통한 실제 회원 ID로 대체
+        String userId = "1";
+
+        createRecipeUseCase.createRecipe(RecipeRequestToCommandMapper.mapToCommand(userId, addRecipeRequest));
+
+        return ResponseEntity.status(CREATED).build();
+    }
+}

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/mapper/RecipeRequestToCommandMapper.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/mapper/RecipeRequestToCommandMapper.java
@@ -1,0 +1,17 @@
+package com.greenbowl.greenbowlserver.recipe.adapter.in.web.mapper;
+
+import com.greenbowl.greenbowlserver.common.utility.FormatConverter;
+import com.greenbowl.greenbowlserver.recipe.adapter.in.web.request.AddRecipeRequest;
+import com.greenbowl.greenbowlserver.recipe.port.in.command.CreateRecipeCommand;
+
+public class RecipeRequestToCommandMapper {
+    public static CreateRecipeCommand mapToCommand(String userId, AddRecipeRequest addRecipeRequest) {
+        return CreateRecipeCommand.of(
+                FormatConverter.parseToLong(userId),
+                addRecipeRequest.getName(),
+                addRecipeRequest.getImageUrl(),
+                FormatConverter.parseToShort(addRecipeRequest.getCookingTime()),
+                FormatConverter.parseToShort(addRecipeRequest.getCalories())
+        );
+    }
+}

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/request/AddRecipeRequest.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/request/AddRecipeRequest.java
@@ -1,0 +1,11 @@
+package com.greenbowl.greenbowlserver.recipe.adapter.in.web.request;
+
+import lombok.Getter;
+
+@Getter
+public class AddRecipeRequest {
+    private String name;
+    private String imageUrl;
+    private String cookingTime;
+    private String calories;
+}

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/EmbeddableNutrition.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/EmbeddableNutrition.java
@@ -1,0 +1,39 @@
+package com.greenbowl.greenbowlserver.recipe.adapter.out.persistence.recipe;
+
+import com.greenbowl.greenbowlserver.recipe.domain.Nutrition;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class EmbeddableNutrition {
+    private short carbohydrate;
+    private short protein;
+    private short fat;
+    private short sodium;
+    private short sugar;
+
+    @Builder
+    private EmbeddableNutrition(short carbohydrate, short protein, short fat, short sodium, short sugar) {
+        this.carbohydrate = carbohydrate;
+        this.protein = protein;
+        this.fat = fat;
+        this.sodium = sodium;
+        this.sugar = sugar;
+    }
+
+    public static EmbeddableNutrition from(Nutrition nutrition) {
+        return EmbeddableNutrition.builder()
+                .carbohydrate(nutrition.getCarbohydrate())
+                .protein(nutrition.getProtein())
+                .fat(nutrition.getFat())
+                .sodium(nutrition.getSodium())
+                .sugar(nutrition.getSugar())
+                .build();
+    }
+}

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeIngredientJpaEntity.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeIngredientJpaEntity.java
@@ -1,0 +1,35 @@
+package com.greenbowl.greenbowlserver.recipe.adapter.out.persistence.recipe;
+
+import com.greenbowl.greenbowlserver.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import com.greenbowl.greenbowlserver.recipe.domain.RecipIngredient;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Entity(name = "recipe_ingredient")
+@Table(name = "recipe_ingredient")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class RecipeIngredientJpaEntity extends BaseGeneralEntity {
+    @Column(nullable = false, length = 255)
+    private String name;
+
+    private short weight;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "recipe_id")
+    private RecipeJpaEntity recipe;
+
+    private RecipeIngredientJpaEntity(String name, short weight) {
+        this.name = name;
+        this.weight = weight;
+    }
+
+    public static RecipeIngredientJpaEntity from(RecipIngredient recipIngredient) {
+        return new RecipeIngredientJpaEntity(recipIngredient.getName(), recipIngredient.getWeight());
+    }
+}

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeJpaEntity.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeJpaEntity.java
@@ -1,0 +1,75 @@
+package com.greenbowl.greenbowlserver.recipe.adapter.out.persistence.recipe;
+
+import com.greenbowl.greenbowlserver.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import com.greenbowl.greenbowlserver.recipe.domain.Recipe;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+import static javax.persistence.CascadeType.*;
+
+@Entity(name = "recipe")
+@Table(name = "recipe")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class RecipeJpaEntity extends BaseGeneralEntity {
+    @Column(nullable = false, length = 255)
+    private String name;
+
+    @Column(length = 4_095)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private int cookingTime;
+
+    @Column(nullable = false)
+    private int calories;
+
+    @Column(length = 511)
+    private String oneLineIntroduction;
+
+    @OneToMany(mappedBy = "recipe", orphanRemoval = true, cascade = {PERSIST, MERGE, REMOVE})
+    private List<RecipeIngredientJpaEntity> recipeIngredients;
+
+    @Column(length = 65_535)
+    private String introduction;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "carbohydrate", column = @Column(nullable = true)),
+            @AttributeOverride(name = "protein", column = @Column(nullable = true)),
+            @AttributeOverride(name = "fat", column = @Column(nullable = true)),
+            @AttributeOverride(name = "sodium", column = @Column(nullable = true)),
+            @AttributeOverride(name = "sugar", column = @Column(nullable = true))
+    })
+    private EmbeddableNutrition nutrition;
+
+    @Builder
+    private RecipeJpaEntity(
+            String name, String imageUrl, int cookingTime, int calories, String oneLineIntroduction,
+            List<RecipeIngredientJpaEntity> recipeIngredientJpaEntities, String introduction,
+            EmbeddableNutrition embeddableNutrition
+    ) {
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.cookingTime = cookingTime;
+        this.calories = calories;
+        this.oneLineIntroduction = oneLineIntroduction;
+        recipeIngredients = recipeIngredientJpaEntities;
+        this.introduction = introduction;
+        nutrition = embeddableNutrition;
+    }
+
+    public static RecipeJpaEntity from(Recipe recipe) {
+        return RecipeJpaEntity.builder()
+                .name(recipe.getName())
+                .imageUrl(recipe.getImageUrl())
+                .cookingTime(recipe.getCookingTime())
+                .calories(recipe.getCalories())
+                .build();
+    }
+}

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipePersistenceAdapter.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipePersistenceAdapter.java
@@ -1,0 +1,18 @@
+package com.greenbowl.greenbowlserver.recipe.adapter.out.persistence.recipe;
+
+import com.greenbowl.greenbowlserver.common.adapter.out.PersistenceAdapter;
+import com.greenbowl.greenbowlserver.recipe.domain.Recipe;
+import com.greenbowl.greenbowlserver.recipe.port.out.SaveRecipePort;
+import lombok.RequiredArgsConstructor;
+
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class RecipePersistenceAdapter implements SaveRecipePort {
+    private final RecipeRepository recipeRepository;
+
+    @Override
+    public void saveRecipe(Recipe recipe) {
+        recipeRepository.save(RecipeJpaEntity.from(recipe));
+    }
+}

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeRepository.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeRepository.java
@@ -1,0 +1,6 @@
+package com.greenbowl.greenbowlserver.recipe.adapter.out.persistence.recipe;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecipeRepository extends JpaRepository<RecipeJpaEntity, Long> {
+}

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/command/CreateRecipeCommand.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/command/CreateRecipeCommand.java
@@ -1,0 +1,37 @@
+package com.greenbowl.greenbowlserver.recipe.port.in.command;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CreateRecipeCommand {
+    private Long userId;
+    private String name;
+    private String imageUrl;
+    private short cookingTime;
+    private short calories;
+
+    @Builder
+    private CreateRecipeCommand(
+            Long userId, String name, String imageUrl, short cookingTime, short calories
+    ) {
+        this.userId = userId;
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.cookingTime = cookingTime;
+        this.calories = calories;
+    }
+
+    public static CreateRecipeCommand of(
+            Long userId, String name, String imageUrl, short cookingTime, short calories
+    ) {
+        return CreateRecipeCommand.builder()
+                .userId(userId)
+                .name(name)
+                .imageUrl(imageUrl)
+                .cookingTime(cookingTime)
+                .calories(calories)
+                .build();
+    }
+}

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/mapper/RecipeCommandToDomainMapper.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/mapper/RecipeCommandToDomainMapper.java
@@ -1,0 +1,15 @@
+package com.greenbowl.greenbowlserver.recipe.port.in.mapper;
+
+import com.greenbowl.greenbowlserver.recipe.domain.Recipe;
+import com.greenbowl.greenbowlserver.recipe.port.in.command.CreateRecipeCommand;
+
+public class RecipeCommandToDomainMapper {
+    public static Recipe mapToDomainEntity(CreateRecipeCommand createRecipeCommand) {
+        return Recipe.of(
+                createRecipeCommand.getName(),
+                createRecipeCommand.getImageUrl(),
+                createRecipeCommand.getCookingTime(),
+                createRecipeCommand.getCalories()
+        );
+    }
+}

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/usecase/CreateRecipeUseCase.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/usecase/CreateRecipeUseCase.java
@@ -1,0 +1,7 @@
+package com.greenbowl.greenbowlserver.recipe.port.in.usecase;
+
+import com.greenbowl.greenbowlserver.recipe.port.in.command.CreateRecipeCommand;
+
+public interface CreateRecipeUseCase {
+    void createRecipe(CreateRecipeCommand createRecipeCommand);
+}

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/out/SaveRecipePort.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/out/SaveRecipePort.java
@@ -1,0 +1,7 @@
+package com.greenbowl.greenbowlserver.recipe.port.out;
+
+import com.greenbowl.greenbowlserver.recipe.domain.Recipe;
+
+public interface SaveRecipePort {
+    void saveRecipe(Recipe recipe);
+}

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/service/CreateRecipeService.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/service/CreateRecipeService.java
@@ -1,0 +1,26 @@
+package com.greenbowl.greenbowlserver.recipe.service;
+
+import com.greenbowl.greenbowlserver.common.application.UseCase;
+import com.greenbowl.greenbowlserver.recipe.port.in.command.CreateRecipeCommand;
+import com.greenbowl.greenbowlserver.recipe.port.in.mapper.RecipeCommandToDomainMapper;
+import com.greenbowl.greenbowlserver.recipe.port.in.usecase.CreateRecipeUseCase;
+import com.greenbowl.greenbowlserver.recipe.port.out.SaveRecipePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_UNCOMMITTED;
+
+@RequiredArgsConstructor
+@UseCase
+/**
+ * 중대한 무결성 이슈가 없고 실시간성이 중요한 북마크 기능의 성능 향상을 위해 Dirty Read 허용
+ */
+@Transactional(isolation = READ_UNCOMMITTED, timeout = 20)
+public class CreateRecipeService implements CreateRecipeUseCase {
+    private final SaveRecipePort saveRecipePort;
+
+    @Override
+    public void createRecipe(CreateRecipeCommand createRecipeCommand) {
+        saveRecipePort.saveRecipe(RecipeCommandToDomainMapper.mapToDomainEntity(createRecipeCommand));
+    }
+}

--- a/recipe-service/recipe-domain/src/main/java/com/greenbowl/greenbowlserver/recipe/configuration/CommonConfig.java
+++ b/recipe-service/recipe-domain/src/main/java/com/greenbowl/greenbowlserver/recipe/configuration/CommonConfig.java
@@ -1,0 +1,11 @@
+package com.greenbowl.greenbowlserver.recipe.configuration;
+
+import com.greenbowl.greenbowlserver.common.application.aop.LoggingAspect;
+import com.greenbowl.greenbowlserver.common.domain.excpeption.GlobalExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({LoggingAspect.class, GlobalExceptionHandler.class})
+public class CommonConfig {
+}

--- a/recipe-service/recipe-domain/src/main/java/com/greenbowl/greenbowlserver/recipe/domain/Nutrition.java
+++ b/recipe-service/recipe-domain/src/main/java/com/greenbowl/greenbowlserver/recipe/domain/Nutrition.java
@@ -1,0 +1,12 @@
+package com.greenbowl.greenbowlserver.recipe.domain;
+
+import lombok.Getter;
+
+@Getter
+public class Nutrition {
+    private short carbohydrate;
+    private short protein;
+    private short fat;
+    private short sodium;
+    private short sugar;
+}

--- a/recipe-service/recipe-domain/src/main/java/com/greenbowl/greenbowlserver/recipe/domain/RecipIngredient.java
+++ b/recipe-service/recipe-domain/src/main/java/com/greenbowl/greenbowlserver/recipe/domain/RecipIngredient.java
@@ -1,0 +1,18 @@
+package com.greenbowl.greenbowlserver.recipe.domain;
+
+import lombok.Getter;
+
+@Getter
+public class RecipIngredient {
+    private String name;
+    private short weight;
+
+    private RecipIngredient(String name, short weight) {
+        this.name = name;
+        this.weight = weight;
+    }
+
+    public static RecipIngredient of(String name, short weight) {
+        return new RecipIngredient(name, weight);
+    }
+}

--- a/recipe-service/recipe-domain/src/main/java/com/greenbowl/greenbowlserver/recipe/domain/Recipe.java
+++ b/recipe-service/recipe-domain/src/main/java/com/greenbowl/greenbowlserver/recipe/domain/Recipe.java
@@ -1,0 +1,42 @@
+package com.greenbowl.greenbowlserver.recipe.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class Recipe {
+    private String name;
+    private String imageUrl;
+    private short cookingTime;
+    private short calories;
+    private String oneLineIntroduction;
+    private List<RecipIngredient> recipeIngredients;
+    private String introduction;
+    private Nutrition nutrition;
+
+    @Builder
+    private Recipe(
+            String name, String imageUrl, short cookingTime, short calories, String oneLineIntroduction,
+            List<RecipIngredient> recipeIngredients, String introduction, Nutrition nutrition
+    ) {
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.cookingTime = cookingTime;
+        this.calories = calories;
+        this.oneLineIntroduction = oneLineIntroduction;
+        this.recipeIngredients = recipeIngredients;
+        this.introduction = introduction;
+        this.nutrition = nutrition;
+    }
+
+    public static Recipe of(String name, String imageUrl, short cookingTime, short calories) {
+        return Recipe.builder()
+                .name(name)
+                .imageUrl(imageUrl)
+                .cookingTime(cookingTime)
+                .calories(calories)
+                .build();
+    }
+}


### PR DESCRIPTION
## resolve [TEAM15-448](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/milestones/OhsJjIHXicVIoLzHC3Wj7)
## resolve #52

## 작업내용
- 레시피 정보 저장 요청
    - 레시피 이름
    - 레시피 이미지 주소
    - 조리 시간
    - 열량 정보
- 레시피 정보 저장 비즈니스 로직
- 데이터베이스에 레시피 정보 저장
    - RecipeJpaEntity
- 201 status code 응답

## 배포
- [x] 성공
- [ ] 실패