### PR TITLE
[TEAM15-453] feat(recipe): 클라이언트는 레시피 서버를 통해 요청한 상세 레시피 정보를 저장할 수 있다

### DIFF
--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/request/AddDetailedRecipeRequest.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/request/AddDetailedRecipeRequest.java
@@ -1,0 +1,17 @@
+package com.greenbowl.greenbowlserver.recipe.adapter.in.web.request;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class AddDetailedRecipeRequest {
+    private String name;
+    private String imageUrl;
+    private String cookingTime;
+    private String calories;
+    private String oneLineIntroduction;
+    private String introduction;
+    private List<UsedIngredientRequest> ingredients;
+    private NutritionRequest nutrition;
+}

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/request/NutritionRequest.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/request/NutritionRequest.java
@@ -1,0 +1,12 @@
+package com.greenbowl.greenbowlserver.recipe.adapter.in.web.request;
+
+import lombok.Getter;
+
+@Getter
+public class NutritionRequest {
+    private String carbohydrate;
+    private String protein;
+    private String fat;
+    private String sodium;
+    private String sugar;
+}

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/request/UsedIngredientRequest.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/request/UsedIngredientRequest.java
@@ -1,0 +1,9 @@
+package com.greenbowl.greenbowlserver.recipe.adapter.in.web.request;
+
+import lombok.Getter;
+
+@Getter
+public class UsedIngredientRequest {
+    private String name;
+    private String weight;
+}

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/command/CreateDetailedRecipeCommand.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/command/CreateDetailedRecipeCommand.java
@@ -1,0 +1,53 @@
+package com.greenbowl.greenbowlserver.recipe.port.in.command;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CreateDetailedRecipeCommand {
+    private Long userId;
+    private String name;
+    private String imageUrl;
+    private short cookingTime;
+    private short calories;
+    private String oneLineIntroduction;
+    private String introduction;
+    private List<IngredientCommand> ingredients;
+    private NutritionCommand nutrition;
+
+    @Builder
+    private CreateDetailedRecipeCommand(
+            Long userId, String name, String imageUrl, short cookingTime, short calories, String oneLineIntroduction,
+            String introduction, List<IngredientCommand> ingredients, NutritionCommand nutrition
+    ) {
+        this.userId = userId;
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.cookingTime = cookingTime;
+        this.calories = calories;
+        this.oneLineIntroduction = oneLineIntroduction;
+        this.introduction = introduction;
+        this.ingredients = ingredients;
+        this.nutrition = nutrition;
+    }
+
+    public static CreateDetailedRecipeCommand of(
+            Long userId, String name, String imageUrl, short cookingTime, short calories, String oneLineIntroduction,
+            String introduction, List<IngredientCommand> ingredients, NutritionCommand nutrition
+    ) {
+        return CreateDetailedRecipeCommand.builder()
+                .userId(userId)
+                .name(name)
+                .imageUrl(imageUrl)
+                .cookingTime(cookingTime)
+                .calories(calories)
+                .oneLineIntroduction(oneLineIntroduction)
+                .introduction(introduction)
+                .ingredients(ingredients)
+                .nutrition(nutrition)
+                .build();
+    }
+}

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/command/IngredientCommand.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/command/IngredientCommand.java
@@ -1,0 +1,19 @@
+package com.greenbowl.greenbowlserver.recipe.port.in.command;
+
+
+import lombok.Getter;
+
+@Getter
+public class IngredientCommand {
+    private String name;
+    private short weight;
+
+    private IngredientCommand(String name, short weight) {
+        this.name = name;
+        this.weight = weight;
+    }
+
+    public static IngredientCommand of(String name, short weight) {
+        return new IngredientCommand(name, weight);
+    }
+}

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/command/NutritionCommand.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/command/NutritionCommand.java
@@ -1,0 +1,33 @@
+package com.greenbowl.greenbowlserver.recipe.port.in.command;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class NutritionCommand {
+    private short carbohydrate;
+    private short protein;
+    private short fat;
+    private short sodium;
+    private short sugar;
+
+    @Builder
+    private NutritionCommand(short carbohydrate, short protein, short fat, short sodium, short sugar) {
+        this.carbohydrate = carbohydrate;
+        this.protein = protein;
+        this.fat = fat;
+        this.sodium = sodium;
+        this.sugar = sugar;
+    }
+
+    public static NutritionCommand of(short carbohydrate, short protein, short fat, short sodium, short sugar) {
+        return NutritionCommand.builder()
+                .carbohydrate(carbohydrate)
+                .protein(protein)
+                .fat(fat)
+                .sodium(sodium)
+                .sugar(sugar)
+                .build();
+    }
+}


### PR DESCRIPTION
## partially resolve [TEAM15-453](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/milestones/MuaTLEng0699_MB2NQ0jh)
## partially resolve #53

## 작업내용
- 상세 레시피 정보 저장 요청
    - 레시피 이름
    - 레시피 이미지 주소
    - 조리 시간
    - 열량 정보
    - 한 줄 소개
    - 사용된 재료 목록
    - 상세 레시피 정보
    - 영양 성분 정보
        - 탄수화물
        - 단백질
        - 지방
        - 나트륨
        - 당류
- 상세 레시피 정보 저장 비즈니스 로직
- 데이터베이스에 상세 레시피 정보 저장
    - RecipeJpaEntity
    - RecipeIngredientEntities
- 201 status code 응답

## 배포
- [ ] 성공
- [x] 실패