### PR TITLE
[TEAM15-537] feat(fridge):Fridge Service 로직 개선 (#81)

### DIFF
--- a/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/in/web/controller/CreateIngredientController.java
+++ b/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/in/web/controller/CreateIngredientController.java
@@ -9,6 +9,7 @@ import com.greenbowl.greenbowlserver.fridge.domain.Ingredient;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -32,11 +33,14 @@ public class CreateIngredientController {
     @PostMapping("/ingredients")
     public ResponseEntity<List<CreateIngredientResponse>> createIngredient(
             @RequestBody @Valid @ApiParam(value = CREATE_INGREDIENT_FORM) List<CreateIngredientRequest> createIngredientRequest) {
+        String userId = "1";
         List<CreateIngredientCommand> command = createIngredientRequest.stream()
                 .map(FridgeRequestToCommandMapper::mapToCommand).collect(Collectors.toList());
 
-        List<Ingredient> ingredient = createIngredientUseCase.createIngredient(command);
-
-        return ResponseEntity.ok(CreateIngredientResponse.from(ingredient));
+        List<Ingredient> ingredient = createIngredientUseCase.createIngredient(Long.parseLong(userId), command);
+        List<CreateIngredientResponse> responses = ingredient.stream()
+                .map(CreateIngredientResponse::from)
+                .collect(Collectors.toList());
+        return ResponseEntity.status(HttpStatus.CREATED).body(responses);
     }
 }

--- a/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/in/web/controller/DeleteIngredientController.java
+++ b/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/in/web/controller/DeleteIngredientController.java
@@ -22,15 +22,15 @@ import java.util.stream.Collectors;
 public class DeleteIngredientController {
     private final DeleteIngredientUseCase deleteIngredientUseCase;
 
-    private static final String DELETE_CATEGORY_ITEM = "냉장고 재료 삭제";
-    private static final String DELETE_CATEGORY_ITEM_DESCRIPTION =
+    private static final String DELETE_INGREDIENT = "냉장고 재료 삭제";
+    private static final String DELETE_INGREDIENT_DESCRIPTION =
             "냉장고 재료ID 를 입력하여 삭제할 수 있습니다.";
-    private static final String DELETE_CATEGORY_ITEM_FORM = "냉장고 재료 삭제 양식";
+    private static final String DELETE_INGREDIENT_FORM = "냉장고 재료 삭제 양식";
 
-    @ApiOperation(value = DELETE_CATEGORY_ITEM, notes = DELETE_CATEGORY_ITEM_DESCRIPTION)
+    @ApiOperation(value = DELETE_INGREDIENT, notes = DELETE_INGREDIENT_DESCRIPTION)
     @DeleteMapping("/ingredients")
     public ResponseEntity<Void> deleteIngredient(
-            @RequestBody @Valid @ApiParam(value = DELETE_CATEGORY_ITEM_FORM) List<DeleteIngredientRequest> deleteIngredientRequest) {
+            @RequestBody @Valid @ApiParam(value = DELETE_INGREDIENT_FORM) List<DeleteIngredientRequest> deleteIngredientRequest) {
         List<DeleteIngredientCommand> deleteIngredientCommands = deleteIngredientRequest.stream()
                         .map(FridgeRequestToCommandMapper::mapToCommand).collect(Collectors.toList());
 

--- a/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/in/web/controller/GetCategoryItemController.java
+++ b/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/in/web/controller/GetCategoryItemController.java
@@ -3,7 +3,9 @@ package com.greenbowl.greenbowlserver.fridge.adapter.in.web.controller;
 import com.greenbowl.greenbowlserver.fridge.adapter.in.web.response.GetCategoryItemBySequenceResponse;
 import com.greenbowl.greenbowlserver.fridge.adapter.in.web.response.GetCategoryItemResponse;
 import com.greenbowl.greenbowlserver.fridge.application.port.in.usecase.GetCategoryItemUseCase;
+import com.greenbowl.greenbowlserver.fridge.application.port.in.usecase.GetDefaultCategoryItemUseCase;
 import com.greenbowl.greenbowlserver.fridge.domain.CategoryItem;
+import com.greenbowl.greenbowlserver.fridge.domain.DefaultCategoryItem;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -19,6 +22,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class GetCategoryItemController {
     private final GetCategoryItemUseCase getCategoryItemUseCase;
+    private final GetDefaultCategoryItemUseCase getDefaultCategoryItemUseCase;
 
     private static final String GET_CATEGORY_ITEM = "카테고리 리스트 조회";
     private static final String GET_CATEGORY_ITEM_DESCRIPTION =
@@ -36,10 +40,23 @@ public class GetCategoryItemController {
         List<CategoryItem> categoryItems = getCategoryItemUseCase
                 .getCategoryItemBySequence(Long.parseLong(userId), Integer.parseInt(sequence));
 
-        List<GetCategoryItemBySequenceResponse> responses =
+        List<DefaultCategoryItem> defaultCategoryItems = getDefaultCategoryItemUseCase
+                .getDefaultCategoryItemBySequence(Integer.parseInt(sequence));
+
+        List<GetCategoryItemBySequenceResponse> responses = new ArrayList<>();
+
+        responses.addAll(
                 categoryItems.stream()
                         .map(GetCategoryItemBySequenceResponse::from)
-                        .collect(Collectors.toList());
+                        .collect(Collectors.toList())
+        );
+
+        responses.addAll(
+                defaultCategoryItems.stream()
+                        .map(GetCategoryItemBySequenceResponse::from)
+                        .collect(Collectors.toList())
+        );
+
         return ResponseEntity.status(HttpStatus.OK).body(responses);
     }
 

--- a/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/in/web/controller/GetIngredientController.java
+++ b/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/in/web/controller/GetIngredientController.java
@@ -1,7 +1,9 @@
 package com.greenbowl.greenbowlserver.fridge.adapter.in.web.controller;
 
 import com.greenbowl.greenbowlserver.fridge.adapter.in.web.response.GetIngredientResponse;
+import com.greenbowl.greenbowlserver.fridge.application.port.in.DefaultIngredientResult;
 import com.greenbowl.greenbowlserver.fridge.application.port.in.IngredientResult;
+import com.greenbowl.greenbowlserver.fridge.application.port.in.usecase.GetDefaultIngredientUseCase;
 import com.greenbowl.greenbowlserver.fridge.application.port.in.usecase.GetIngredientUseCase;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,6 +20,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class GetIngredientController {
     private final GetIngredientUseCase getIngredientUseCase;
+    private final GetDefaultIngredientUseCase getDefaultIngredientUseCase;
 
     private static final String GET_INGREDIENT = "냉장고 재료 조회";
     private static final String GET_CATEGORY_ITEM_DESCRIPTION =
@@ -27,11 +31,22 @@ public class GetIngredientController {
     public ResponseEntity<List<GetIngredientResponse>> getIngredient() {
         String userId = "1";
 
-        List<IngredientResult> responses = getIngredientUseCase.getIngredients(Long.parseLong(userId));
-        List<GetIngredientResponse> result = responses.stream()
+        List<IngredientResult> ingredientResults = getIngredientUseCase.getIngredients(Long.parseLong(userId));
+        List<DefaultIngredientResult> defaultIngredientResults = getDefaultIngredientUseCase.getDefaultIngredients(Long.parseLong(userId));
+        List<GetIngredientResponse> responses = new ArrayList<>();
 
-                .map(GetIngredientResponse::from).collect(Collectors.toList());
+        responses.addAll(
+                ingredientResults.stream()
+                        .map(GetIngredientResponse::from)
+                        .collect(Collectors.toList())
+        );
 
-        return ResponseEntity.status(HttpStatus.OK).body(result);
+        responses.addAll(
+                defaultIngredientResults.stream()
+                        .map(GetIngredientResponse::from)
+                        .collect(Collectors.toList())
+        );
+
+        return ResponseEntity.status(HttpStatus.OK).body(responses);
     }
 }

--- a/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/in/web/response/CreateIngredientResponse.java
+++ b/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/in/web/response/CreateIngredientResponse.java
@@ -1,12 +1,10 @@
 package com.greenbowl.greenbowlserver.fridge.adapter.in.web.response;
 
+import com.greenbowl.greenbowlserver.fridge.domain.DefaultIngredient;
 import com.greenbowl.greenbowlserver.fridge.domain.Ingredient;
 import com.greenbowl.greenbowlserver.fridge.domain.wrapper.WrapperAccessor;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -14,14 +12,20 @@ public class CreateIngredientResponse {
     private Long id;
     private int quantity;
     private String storageMethod;
-    public static List<CreateIngredientResponse> from(List<Ingredient> ingredients) {
-        return ingredients.stream().map(
-                ingredient ->
-                CreateIngredientResponse.builder()
+
+    public static CreateIngredientResponse from(Ingredient ingredient) {
+        return CreateIngredientResponse.builder()
                         .id(ingredient.getId())
                         .quantity(WrapperAccessor.getQuantity(ingredient.getQuantity()))
                         .storageMethod(ingredient.getStorageMethod().getDescription())
-                        .build()
-        ).collect(Collectors.toList());
+                        .build();
+    }
+
+    public static CreateIngredientResponse from(DefaultIngredient ingredient) {
+        return CreateIngredientResponse.builder()
+                                .id(ingredient.getId())
+                                .quantity(WrapperAccessor.getQuantity(ingredient.getQuantity()))
+                                .storageMethod(ingredient.getStorageMethod().getDescription())
+                                .build();
     }
 }

--- a/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/in/web/response/GetCategoryItemBySequenceResponse.java
+++ b/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/in/web/response/GetCategoryItemBySequenceResponse.java
@@ -1,6 +1,7 @@
 package com.greenbowl.greenbowlserver.fridge.adapter.in.web.response;
 
 import com.greenbowl.greenbowlserver.fridge.domain.CategoryItem;
+import com.greenbowl.greenbowlserver.fridge.domain.DefaultCategoryItem;
 import com.greenbowl.greenbowlserver.fridge.domain.wrapper.WrapperAccessor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,15 +11,26 @@ import lombok.Getter;
 @Getter
 @Builder
 public class GetCategoryItemBySequenceResponse {
-    private Long categoryItemId;
+    private Long id;
     private String categoryDetail;
     private int sequence;
+    private boolean isDefault;
 
     public static GetCategoryItemBySequenceResponse from (CategoryItem categoryItem) {
         return GetCategoryItemBySequenceResponse.builder()
                 .sequence(categoryItem.getCategory().getSequence())
-                .categoryItemId(categoryItem.getId())
+                .id(categoryItem.getId())
                 .categoryDetail(WrapperAccessor.getCategoryDetail(categoryItem.getCategoryDetail()))
+                .isDefault(false)
+                .build();
+    }
+
+    public static GetCategoryItemBySequenceResponse from (DefaultCategoryItem defaultCategoryItem){
+        return GetCategoryItemBySequenceResponse.builder()
+                .id(defaultCategoryItem.getId())
+                .sequence(defaultCategoryItem.getCategory().getSequence())
+                .categoryDetail(WrapperAccessor.getCategoryDetail(defaultCategoryItem.getCategoryDetail()))
+                .isDefault(true)
                 .build();
     }
 }

--- a/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/in/web/response/GetIngredientResponse.java
+++ b/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/in/web/response/GetIngredientResponse.java
@@ -1,5 +1,6 @@
 package com.greenbowl.greenbowlserver.fridge.adapter.in.web.response;
 
+import com.greenbowl.greenbowlserver.fridge.application.port.in.DefaultIngredientResult;
 import com.greenbowl.greenbowlserver.fridge.application.port.in.IngredientResult;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,6 +19,7 @@ public class GetIngredientResponse {
     private Long categoryId;
     private int sequence;
     private String categoryDetail;
+    private boolean isDefault;
 
     public static GetIngredientResponse from(IngredientResult ingredientResult) {
         return GetIngredientResponse.builder()
@@ -28,6 +30,20 @@ public class GetIngredientResponse {
                 .categoryId(ingredientResult.getCategoryId())
                 .sequence(ingredientResult.getSequence())
                 .categoryDetail(ingredientResult.getCategoryDetail())
+                .isDefault(false)
+                .build();
+    }
+
+    public static GetIngredientResponse from(DefaultIngredientResult defaultIngredientResult) {
+        return GetIngredientResponse.builder()
+                .id(defaultIngredientResult.getId())
+                .quantity(defaultIngredientResult.getQuantity())
+                .storageMethod(defaultIngredientResult.getStorageMethod())
+                .expirationDate(defaultIngredientResult.getExpirationDate())
+                .categoryId(defaultIngredientResult.getCategoryId())
+                .sequence(defaultIngredientResult.getSequence())
+                .categoryDetail(defaultIngredientResult.getCategoryDetail())
+                .isDefault(true)
                 .build();
     }
 }

--- a/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/in/web/response/UpdateIngredientResponse.java
+++ b/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/in/web/response/UpdateIngredientResponse.java
@@ -1,5 +1,6 @@
 package com.greenbowl.greenbowlserver.fridge.adapter.in.web.response;
 
+import com.greenbowl.greenbowlserver.fridge.application.port.in.DefaultIngredientResult;
 import com.greenbowl.greenbowlserver.fridge.application.port.in.IngredientResult;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,6 +27,17 @@ public class UpdateIngredientResponse {
                 .expirationDate(ingredientResult.getExpirationDate())
                 .sequence(ingredientResult.getSequence())
                 .categoryDetail(ingredientResult.getCategoryDetail())
+                .build();
+    }
+
+    public static UpdateIngredientResponse from(DefaultIngredientResult defaultIngredientResult) {
+        return UpdateIngredientResponse.builder()
+                .id(defaultIngredientResult.getId())
+                .quantity(defaultIngredientResult.getQuantity())
+                .storageMethod(defaultIngredientResult.getStorageMethod())
+                .expirationDate(defaultIngredientResult.getExpirationDate())
+                .sequence(defaultIngredientResult.getSequence())
+                .categoryDetail(defaultIngredientResult.getCategoryDetail())
                 .build();
     }
 }

--- a/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/out/mapper/FridgeJpaEntityToDomainMapper.java
+++ b/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/out/mapper/FridgeJpaEntityToDomainMapper.java
@@ -1,8 +1,12 @@
 package com.greenbowl.greenbowlserver.fridge.adapter.out.mapper;
 
 import com.greenbowl.greenbowlserver.fridge.adapter.out.persistance.categoryitem.CategoryItemJpaEntity;
+import com.greenbowl.greenbowlserver.fridge.adapter.out.persistance.defaultcategoryitem.DefaultCategoryItemJpaEntity;
+import com.greenbowl.greenbowlserver.fridge.adapter.out.persistance.defaultingredient.DefaultIngredientJpaEntity;
 import com.greenbowl.greenbowlserver.fridge.adapter.out.persistance.ingredient.IngredientJpaEntity;
 import com.greenbowl.greenbowlserver.fridge.domain.CategoryItem;
+import com.greenbowl.greenbowlserver.fridge.domain.DefaultCategoryItem;
+import com.greenbowl.greenbowlserver.fridge.domain.DefaultIngredient;
 import com.greenbowl.greenbowlserver.fridge.domain.Ingredient;
 
 public class FridgeJpaEntityToDomainMapper {
@@ -26,4 +30,22 @@ public class FridgeJpaEntityToDomainMapper {
                 .build();
     }
 
+    public static DefaultCategoryItem mapToDomainEntity(DefaultCategoryItemJpaEntity defaultCategoryItemJpaEntity) {
+        return DefaultCategoryItem.builder()
+                .id(defaultCategoryItemJpaEntity.getId())
+                .category(defaultCategoryItemJpaEntity.getCategory())
+                .categoryDetail(defaultCategoryItemJpaEntity.getCategoryDetail())
+                .build();
+    }
+
+    public static DefaultIngredient mapToDomainEntity(DefaultIngredientJpaEntity defaultIngredientJpaEntity) {
+        return DefaultIngredient.builder()
+                .id(defaultIngredientJpaEntity.getId())
+                .userId(defaultIngredientJpaEntity.getUserId())
+                .expirationDate(defaultIngredientJpaEntity.getExpirationDate())
+                .quantity(defaultIngredientJpaEntity.getQuantity())
+                .storageMethod(defaultIngredientJpaEntity.getStorageMethod())
+                .defaultCategoryId(defaultIngredientJpaEntity.getDefaultCategoryItemJpaEntity().getId())
+                .build();
+    }
 }

--- a/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/out/persistance/categoryitem/CategoryItemJpaRepository.java
+++ b/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/out/persistance/categoryitem/CategoryItemJpaRepository.java
@@ -4,7 +4,6 @@ import com.greenbowl.greenbowlserver.fridge.domain.wrapper.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface CategoryItemJpaRepository extends JpaRepository<CategoryItemJpaEntity, Long> {
     CategoryItemJpaEntity findByUserIdAndDeleteYnFalse(Long userId);
@@ -12,7 +11,7 @@ public interface CategoryItemJpaRepository extends JpaRepository<CategoryItemJpa
 
     CategoryItemJpaEntity findByUserIdAndIdAndDeleteYnFalse(Long userId, Long categoryId);
 
-    Optional<CategoryItemJpaEntity> findByCategoryDetail(String categoryDetail);
-
     List<CategoryItemJpaEntity> findAllByUserIdAndCategoryAndDeleteYnFalse(Long userId, Category category);
+
+    List<CategoryItemJpaEntity> findAllByUserIdAndIdIn(Long userId, List<Long> categoryIds);
 }

--- a/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/out/persistance/ingredient/IngredientJpaRepository.java
+++ b/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/out/persistance/ingredient/IngredientJpaRepository.java
@@ -1,12 +1,12 @@
 package com.greenbowl.greenbowlserver.fridge.adapter.out.persistance.ingredient;
 
+import com.greenbowl.greenbowlserver.fridge.adapter.out.persistance.categoryitem.CategoryItemJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface IngredientJpaRepository extends JpaRepository<IngredientJpaEntity, Long> {
-//    IngredientJpaEntity findByCategoryItemAndDeleteYnFalse(CategoryItemJpaEntity categoryItemJpaEntity);
-    IngredientJpaEntity findByCategoryItemJpaEntity_IdAndDeleteYnFalse(Long categoryItemId);
+    List<IngredientJpaEntity> findAllByCategoryItemJpaEntityAndDeleteYnFalse(CategoryItemJpaEntity categoryItemJpaEntity);
 
-    List<IngredientJpaEntity> findAllByCategoryItemJpaEntity_IdAndDeleteYnFalse(Long id);
+    List<IngredientJpaEntity> findAllByCategoryItemJpaEntityIdInAndDeleteYnFalse(List<Long> categoryIds);
 }

--- a/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/out/persistance/ingredient/IngredientPersistenceAdapter.java
+++ b/fridge-service/fridge-adapters/src/main/java/com/greenbowl/greenbowlserver/fridge/adapter/out/persistance/ingredient/IngredientPersistenceAdapter.java
@@ -5,15 +5,18 @@ import com.greenbowl.greenbowlserver.fridge.adapter.out.persistance.categoryitem
 import com.greenbowl.greenbowlserver.fridge.adapter.out.persistance.categoryitem.CategoryItemJpaRepository;
 import com.greenbowl.greenbowlserver.fridge.application.port.in.IngredientResult;
 import com.greenbowl.greenbowlserver.fridge.application.port.in.command.DeleteIngredientCommand;
-import com.greenbowl.greenbowlserver.fridge.application.port.out.*;
+import com.greenbowl.greenbowlserver.fridge.application.port.out.CreateIngredientPort;
+import com.greenbowl.greenbowlserver.fridge.application.port.out.DeleteIngredientPort;
+import com.greenbowl.greenbowlserver.fridge.application.port.out.GetIngredientPort;
+import com.greenbowl.greenbowlserver.fridge.application.port.out.UpdateIngredientPort;
 import com.greenbowl.greenbowlserver.fridge.domain.CategoryItem;
 import com.greenbowl.greenbowlserver.fridge.domain.Ingredient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Component
@@ -24,13 +27,23 @@ public class IngredientPersistenceAdapter implements
     private final CategoryItemJpaRepository categoryItemJpaRepository;
 
     @Override
-    public List<Ingredient> saveIngredient(List<Ingredient> ingredients) {
+    public List<Ingredient> saveIngredient(Long userId, List<Ingredient> ingredients) {
+        List<Long> categoryIds = ingredients.stream()
+                .map(Ingredient::getCategoryId)
+                .distinct()
+                .collect(Collectors.toList());
+
+        Map<Long, CategoryItemJpaEntity> categoryMap = categoryItemJpaRepository
+                .findAllByUserIdAndIdIn(userId, categoryIds)
+                .stream()
+                .collect(Collectors.toMap(CategoryItemJpaEntity::getId, Function.identity()));
+
         List<IngredientJpaEntity> entities = ingredients.stream()
                 .map(ingredient -> {
-
-                    CategoryItemJpaEntity categoryItemJpaEntity = categoryItemJpaRepository.findById(ingredient.getCategoryId())
-                            .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없음: " + ingredient.getCategoryId()));
-
+                    CategoryItemJpaEntity categoryItemJpaEntity = categoryMap.get(ingredient.getCategoryId());
+                    if (categoryItemJpaEntity == null) {
+                        throw new IllegalArgumentException("카테고리를 찾을 수 없음: " + ingredient.getCategoryId());
+                    }
                     return IngredientJpaEntity.from(ingredient, categoryItemJpaEntity);
                 })
                 .collect(Collectors.toList());
@@ -47,13 +60,12 @@ public class IngredientPersistenceAdapter implements
         List<CategoryItemJpaEntity> categoryItemEntities = categoryItemJpaRepository
                 .findAllByUserIdAndDeleteYnFalse(userId);
 
-        List<IngredientJpaEntity> ingredientEntities = new ArrayList<>();
+        List<Long> categoryIds = categoryItemEntities.stream()
+                .map(CategoryItemJpaEntity::getId)
+                .collect(Collectors.toList());
 
-        for (CategoryItemJpaEntity categoryItemEntity : categoryItemEntities) {
-            List<IngredientJpaEntity> ingredientsForCategory =
-                    ingredientJpaRepository.findAllByCategoryItemJpaEntity_IdAndDeleteYnFalse(categoryItemEntity.getId());
-            ingredientEntities.addAll(ingredientsForCategory);
-        }
+        List<IngredientJpaEntity> ingredientEntities = ingredientJpaRepository
+                .findAllByCategoryItemJpaEntityIdInAndDeleteYnFalse(categoryIds);
 
         return ingredientEntities.stream()
                 .map(FridgeJpaEntityToDomainMapper::mapToDomainEntity)

--- a/fridge-service/fridge-application/src/main/java/com/greenbowl/greenbowlserver/fridge/application/port/in/usecase/CreateIngredientUseCase.java
+++ b/fridge-service/fridge-application/src/main/java/com/greenbowl/greenbowlserver/fridge/application/port/in/usecase/CreateIngredientUseCase.java
@@ -6,5 +6,5 @@ import com.greenbowl.greenbowlserver.fridge.domain.Ingredient;
 import java.util.List;
 
 public interface CreateIngredientUseCase {
-    List<Ingredient> createIngredient(List<CreateIngredientCommand> command);
+    List<Ingredient> createIngredient(Long userId, List<CreateIngredientCommand> command);
 }

--- a/fridge-service/fridge-application/src/main/java/com/greenbowl/greenbowlserver/fridge/application/port/out/CreateIngredientPort.java
+++ b/fridge-service/fridge-application/src/main/java/com/greenbowl/greenbowlserver/fridge/application/port/out/CreateIngredientPort.java
@@ -5,5 +5,5 @@ import com.greenbowl.greenbowlserver.fridge.domain.Ingredient;
 import java.util.List;
 
 public interface CreateIngredientPort {
-    List<Ingredient> saveIngredient(List<Ingredient> ingredients);
+    List<Ingredient> saveIngredient(Long userId, List<Ingredient> ingredients);
 }

--- a/fridge-service/fridge-application/src/main/java/com/greenbowl/greenbowlserver/fridge/application/service/CreateIngredientService.java
+++ b/fridge-service/fridge-application/src/main/java/com/greenbowl/greenbowlserver/fridge/application/service/CreateIngredientService.java
@@ -19,12 +19,12 @@ public class CreateIngredientService implements CreateIngredientUseCase {
     private final CreateIngredientPort createIngredientPort;
 
     @Override
-    public List<Ingredient> createIngredient(List<CreateIngredientCommand> createIngredientCommands) {
+    public List<Ingredient> createIngredient(Long userId, List<CreateIngredientCommand> createIngredientCommands) {
 
         List<Ingredient> ingredients = createIngredientCommands.stream()
                 .map(IngredientCommandToDomainMapper::mapToDomainEntity)
                 .collect(Collectors.toList());
 
-        return createIngredientPort.saveIngredient(ingredients);
+        return createIngredientPort.saveIngredient(userId, ingredients);
     }
 }


### PR DESCRIPTION
## resolve [TEAM15-537](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/tasks/kKw972Q2mlJmWg6K5As8F)
## resolve #81 

## 작업내용
- Fridge Service CategoryItem 로직 개선
- categoryItem Repository 내 사용하지 않는 메서드 삭제
- categoryItem Repository 조회시 List타입의 CategoryId 및 userId 로 조회 메서드 추가
- categoryItem Get 요청시, Default CategoryItem 추가 및 응답 값 내 isDefault 값으로 구분
- Fridge Service Ingredient 로직 개선
- Ingredient Adapter 로직 개선
- ingredient Get 요청시, Default Ingredient 추가 및 응답 값 내 isDefault 값으로 구분