### PR TITLE
[TEAM15-525] feat(user): 클라이언트는 회원 서버를 통해 로그인 서비스를 이용할 수 있다

### DIFF
--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/utility/LogConstant.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/utility/LogConstant.java
@@ -1,0 +1,6 @@
+package com.greenbowl.greenbowlserver.common.utility;
+
+public class LogConstant {
+    public static final String LOG_ERROR_MESSAGE = "Error exception occurred: {}";
+    public static final String LOG_WARN_MESSAGE = "Warning exception occurred: {}";
+}

--- a/recipe-service/recipe-adapters/src/main/resources/application.yml
+++ b/recipe-service/recipe-adapters/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
     password: postgrepassword
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
       properties:
         hibernate:
           dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/in/web/ApiConstant.java
+++ b/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/in/web/ApiConstant.java
@@ -1,0 +1,5 @@
+package com.greenbowl.greenbowlserver.user.adapter.in.web;
+
+public class ApiConstant {
+    public static final String EMAIL_EXAMPLE = "tester1@tester.com";
+}

--- a/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/in/web/configuration/WebSecurityConfig.java
+++ b/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/in/web/configuration/WebSecurityConfig.java
@@ -1,0 +1,48 @@
+package com.greenbowl.greenbowlserver.user.adapter.in.web.configuration;
+
+import com.greenbowl.greenbowlserver.user.adapter.in.web.security.CustomAuthenticationEntryPoint;
+import com.greenbowl.greenbowlserver.user.adapter.in.web.security.JwtAuthenticationFilter;
+import com.greenbowl.greenbowlserver.user.port.out.AuthenticationPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
+public class WebSecurityConfig extends GlobalMethodSecurityConfiguration {
+    private final AuthenticationPort authenticationPort;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .exceptionHandling().authenticationEntryPoint(customAuthenticationEntryPoint) // 인증되지 않았을 시 custom entry point 사용
+                .and()
+                .httpBasic().disable() // JWT 사용
+                .cors()
+                .and()
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeHttpRequests()
+                .antMatchers("/", "/swagger-ui/**", "/v2/api-docs", "/swagger-resources/**",
+                        "/**/login", "/**/token")
+                .permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .addFilterBefore(new JwtAuthenticationFilter(authenticationPort, customAuthenticationEntryPoint),
+                        UsernamePasswordAuthenticationFilter.class)
+                .logout().permitAll();
+
+        return http.build();
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/in/web/controller/AuthenticationController.java
+++ b/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/in/web/controller/AuthenticationController.java
@@ -1,0 +1,42 @@
+package com.greenbowl.greenbowlserver.user.adapter.in.web.controller;
+
+import com.greenbowl.greenbowlserver.common.adapter.in.WebAdapter;
+import com.greenbowl.greenbowlserver.user.adapter.in.web.mapper.UserRequestToCommandMapper;
+import com.greenbowl.greenbowlserver.user.adapter.in.web.request.SignInRequest;
+import com.greenbowl.greenbowlserver.user.adapter.in.web.response.SignInResponse;
+import com.greenbowl.greenbowlserver.user.port.in.AuthenticationResult;
+import com.greenbowl.greenbowlserver.user.port.in.command.SignInCommand;
+import com.greenbowl.greenbowlserver.user.port.in.usecase.AuthenticationUseCase;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class AuthenticationController {
+    private final AuthenticationUseCase authenticationUseCase;
+
+    private static final String SIGN_IN = "로그인";
+    private static final String SIGN_IN_DESCRIPTION = "email을 입력해 로그인을 할 수 있습니다.";
+    private static final String SIGN_IN_FORM = "로그인 양식";
+
+    @ApiOperation(value = SIGN_IN, notes = SIGN_IN_DESCRIPTION)
+    @PostMapping("/login")
+    public ResponseEntity<SignInResponse> signInUser
+            (@RequestBody @ApiParam(value = SIGN_IN_FORM) SignInRequest signInRequest) {
+        SignInCommand signInCommand = UserRequestToCommandMapper.mapToCommand(signInRequest);
+        AuthenticationResult authenticationResult = authenticationUseCase.signInUser(signInCommand);
+
+        if (authenticationResult.isNewUser()) {
+            return ResponseEntity.status(HttpStatus.CREATED).body(SignInResponse.from(authenticationResult));
+        }
+
+        return ResponseEntity.status(HttpStatus.OK).body(SignInResponse.from(authenticationResult));
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/in/web/mapper/UserRequestToCommandMapper.java
+++ b/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/in/web/mapper/UserRequestToCommandMapper.java
@@ -1,0 +1,10 @@
+package com.greenbowl.greenbowlserver.user.adapter.in.web.mapper;
+
+import com.greenbowl.greenbowlserver.user.adapter.in.web.request.SignInRequest;
+import com.greenbowl.greenbowlserver.user.port.in.command.SignInCommand;
+
+public class UserRequestToCommandMapper {
+    public static SignInCommand mapToCommand(SignInRequest signInRequest) {
+        return SignInCommand.of(signInRequest.getEmail());
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/in/web/request/SignInRequest.java
+++ b/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/in/web/request/SignInRequest.java
@@ -1,0 +1,14 @@
+package com.greenbowl.greenbowlserver.user.adapter.in.web.request;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+
+import static com.greenbowl.greenbowlserver.user.adapter.in.web.ApiConstant.EMAIL_EXAMPLE;
+
+@Getter
+public class SignInRequest {
+    private static final String EMAIL_VALUE = "사용자 이메일 주소";
+
+    @ApiModelProperty(value = EMAIL_VALUE, example = EMAIL_EXAMPLE)
+    private String email;
+}

--- a/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/in/web/response/SignInResponse.java
+++ b/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/in/web/response/SignInResponse.java
@@ -1,0 +1,40 @@
+package com.greenbowl.greenbowlserver.user.adapter.in.web.response;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.greenbowl.greenbowlserver.user.port.in.AuthenticationResult;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class SignInResponse {
+    private final Long userId;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private final LocalDateTime loggedInAt;
+
+    private final boolean isNewUser;
+    private final String accessToken;
+
+    @Builder
+    private SignInResponse(Long userId, String accessToken, boolean isNewUser, LocalDateTime loggedInAt) {
+        this.userId = userId;
+        this.accessToken = accessToken;
+        this.isNewUser = isNewUser;
+        this.loggedInAt = loggedInAt;
+    }
+
+    public static SignInResponse from(AuthenticationResult authenticationResult) {
+        return SignInResponse.builder()
+                .userId(authenticationResult.getUserId())
+                .loggedInAt(authenticationResult.getLastLoggedInAt())
+                .isNewUser(authenticationResult.isNewUser())
+                .accessToken(authenticationResult.getAccessToken())
+                .build();
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/in/web/security/CustomAuthenticationEntryPoint.java
+++ b/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/in/web/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,53 @@
+package com.greenbowl.greenbowlserver.user.adapter.in.web.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.greenbowl.greenbowlserver.common.domain.excpeption.ErrorResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static com.greenbowl.greenbowlserver.common.utility.LogConstant.LOG_ERROR_MESSAGE;
+import static com.greenbowl.greenbowlserver.common.utility.LogConstant.LOG_WARN_MESSAGE;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final Logger log = LoggerFactory.getLogger(CustomAuthenticationEntryPoint.class);
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException e) throws IOException {
+        ErrorResponse errorResponse;
+
+        if (e instanceof UsernameNotFoundException) {
+            log.warn(LOG_WARN_MESSAGE, e.getMessage(), e);
+
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+            errorResponse = ErrorResponse.builder()
+                    .statusCode(HttpServletResponse.SC_UNAUTHORIZED)
+                    .message(e.getMessage())
+                    .build();
+        } else {
+            log.error(LOG_ERROR_MESSAGE, e.getMessage(), e);
+
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+            errorResponse = ErrorResponse.builder()
+                    .statusCode(HttpServletResponse.SC_FORBIDDEN)
+                    .message(e.getMessage())
+                    .build();
+        }
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+        response.flushBuffer();
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/in/web/security/JwtAuthenticationFilter.java
+++ b/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/in/web/security/JwtAuthenticationFilter.java
@@ -1,0 +1,65 @@
+package com.greenbowl.greenbowlserver.user.adapter.in.web.security;
+
+import com.greenbowl.greenbowlserver.user.port.out.AuthenticationPort;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    public static final String TOKEN_HEADER = "Authorization";
+    public static final String TOKEN_PREFIX = "Bearer ";
+
+    private final AuthenticationPort authenticationPort;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+
+    @Override
+    protected void doFilterInternal
+            (HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String ipAddress = request.getRemoteAddr();
+        log.info("Request IP Address: " + ipAddress);
+
+        String token = resolveTokenFromRequest(request);
+
+        if (StringUtils.hasText(token) && authenticationPort.validateToken(token)) {
+            try {
+                Authentication authentication = authenticationPort.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                log.info(String.format("[%s] -> %s", authenticationPort.parseUserId(token), request.getRequestURI()));
+            } catch (UsernameNotFoundException e) {
+                customAuthenticationEntryPoint.commence(request, response, e);
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveTokenFromRequest(HttpServletRequest request) {
+        String token = request.getHeader(TOKEN_HEADER);
+
+        if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+            return token.substring(TOKEN_PREFIX.length());
+        }
+
+        return null;
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/out/mapper/UserJpaEntityToDomainMapper.java
+++ b/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/out/mapper/UserJpaEntityToDomainMapper.java
@@ -1,0 +1,22 @@
+package com.greenbowl.greenbowlserver.user.adapter.out.mapper;
+
+import com.greenbowl.greenbowlserver.common.utility.FormatValidator;
+import com.greenbowl.greenbowlserver.user.adapter.out.persistence.user.UserJpaEntity;
+import com.greenbowl.greenbowlserver.user.domain.User;
+
+import java.util.Optional;
+
+public class UserJpaEntityToDomainMapper {
+
+    public static Optional<User> mapToDomainEntity(UserJpaEntity userJpaEntity) {
+        return Optional.ofNullable(userJpaEntity)
+                .filter(FormatValidator::hasValue)
+                .map(entity -> User.builder()
+                        .id(entity.getId())
+                        .email(entity.getEmail())
+                        .createdAt(entity.getCreatedAt())
+                        .modifiedAt(entity.getModifiedAt())
+                        .lastLoggedInAt(entity.getLastLoggedInAt())
+                        .build());
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/out/persistence/security/JwtTokenProvider.java
+++ b/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/out/persistence/security/JwtTokenProvider.java
@@ -1,0 +1,97 @@
+package com.greenbowl.greenbowlserver.user.adapter.out.persistence.security;
+
+import com.greenbowl.greenbowlserver.user.domain.User;
+import com.greenbowl.greenbowlserver.user.domain.wrapper.WrapperAccessor;
+import com.greenbowl.greenbowlserver.user.port.out.AuthenticationPort;
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.annotation.PostConstruct;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider implements AuthenticationPort {
+    private final UserDetailsService userDetailsService;
+
+    private static final String KEY_EMAIL = "email";
+    private static final long ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 10;
+
+    private static final String ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE = "토큰이 비어 있습니다.";
+    private static final String MALFORMED_JWT_EXCEPTION_MESSAGE = "유효하지 않은 토큰입니다.";
+    private static final String UNSUPPORTED_JWT_EXCEPTION_MESSAGE = "지원하지 않는 토큰 형식입니다.";
+
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+
+    @PostConstruct
+    public void init() {
+        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+    }
+
+    @Override
+    public String generateAccessToken(User user) {
+        Claims claims = generateToken(user.getId().toString(), WrapperAccessor.getEmailValue(user.getEmail()));
+
+        Date now = new Date();
+        Date expirationDate = new Date(now.getTime() + ACCESS_TOKEN_EXPIRATION_TIME);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expirationDate)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    @Override
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(parseUserId(token));
+
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    @Override
+    public String parseUserId(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    @Override
+    public boolean validateToken(String token) {
+        if (!StringUtils.hasText(token)) {
+            return false;
+        }
+
+        Claims claims = parseClaims(token);
+        return !claims.getExpiration().before(new Date());
+    }
+
+    private Claims generateToken(String userId, String email) {
+        Claims claims = Jwts.claims().setSubject(userId);
+        claims.put(KEY_EMAIL, email);
+
+        return claims;
+    }
+
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE, e);
+        } catch (MalformedJwtException e) {
+            throw new MalformedJwtException(MALFORMED_JWT_EXCEPTION_MESSAGE, e);
+        } catch (UnsupportedJwtException e) {
+            throw new UnsupportedJwtException(UNSUPPORTED_JWT_EXCEPTION_MESSAGE, e);
+        }
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/out/persistence/user/UserJpaEntity.java
+++ b/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/out/persistence/user/UserJpaEntity.java
@@ -1,0 +1,55 @@
+package com.greenbowl.greenbowlserver.user.adapter.out.persistence.user;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.greenbowl.greenbowlserver.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import com.greenbowl.greenbowlserver.user.domain.User;
+import com.greenbowl.greenbowlserver.user.domain.wrapper.Email;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity(name = "user")
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class UserJpaEntity extends BaseGeneralEntity {
+    @Convert(converter = Email.EmailConverter.class)
+    @Column(nullable = false, unique = true, length = 60)
+    @JsonIgnore
+    private Email email;
+
+    @LastModifiedDate
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime lastLoggedInAt;
+
+    @Builder
+    private UserJpaEntity(Email email, LocalDateTime lastLoggedInAt) {
+        this.email = email;
+        ;
+        this.lastLoggedInAt = lastLoggedInAt;
+    }
+
+    public static UserJpaEntity from(User user) {
+        return UserJpaEntity.builder()
+                .email(user.getEmail())
+                .lastLoggedInAt(LocalDateTime.now())
+                .build();
+    }
+
+    public void updateLoginTime() {
+        lastLoggedInAt = LocalDateTime.now();
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/out/persistence/user/UserPersistenceAdapter.java
+++ b/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/out/persistence/user/UserPersistenceAdapter.java
@@ -1,0 +1,42 @@
+package com.greenbowl.greenbowlserver.user.adapter.out.persistence.user;
+
+import com.greenbowl.greenbowlserver.common.adapter.out.PersistenceAdapter;
+import com.greenbowl.greenbowlserver.user.adapter.out.mapper.UserJpaEntityToDomainMapper;
+import com.greenbowl.greenbowlserver.user.domain.User;
+import com.greenbowl.greenbowlserver.user.domain.wrapper.Email;
+import com.greenbowl.greenbowlserver.user.port.out.FindUserPort;
+import com.greenbowl.greenbowlserver.user.port.out.SignUpPort;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class UserPersistenceAdapter implements SignUpPort, FindUserPort {
+    private final UserRepository userRepository;
+
+    @Override
+    public User saveUser(User user) {
+        return UserJpaEntityToDomainMapper.mapToDomainEntity(userRepository.save(UserJpaEntity.from(user))).get();
+    }
+
+    @Override
+    public boolean isUserExists(String email) {
+        return userRepository.existsByEmailAndDeleteYnFalse(Email.of(email));
+    }
+
+    @Override
+    public Optional<User> findById(Long userId) {
+        UserJpaEntity userJpaEntity = userRepository.findByIdAndDeleteYnFalse(userId);
+
+        return UserJpaEntityToDomainMapper.mapToDomainEntity(userJpaEntity);
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        UserJpaEntity userJpaEntity = userRepository.findByEmailAndDeleteYnFalse(Email.of(email));
+
+        return UserJpaEntityToDomainMapper.mapToDomainEntity(userJpaEntity);
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/out/persistence/user/UserRepository.java
+++ b/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/adapter/out/persistence/user/UserRepository.java
@@ -1,0 +1,12 @@
+package com.greenbowl.greenbowlserver.user.adapter.out.persistence.user;
+
+import com.greenbowl.greenbowlserver.user.domain.wrapper.Email;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<UserJpaEntity, Long> {
+    boolean existsByEmailAndDeleteYnFalse(Email email);
+
+    UserJpaEntity findByIdAndDeleteYnFalse(Long id);
+
+    UserJpaEntity findByEmailAndDeleteYnFalse(Email email);
+}

--- a/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/configuration/CommonConfig.java
+++ b/user-service/user-adapters/src/main/java/com/greenbowl/greenbowlserver/user/configuration/CommonConfig.java
@@ -1,0 +1,11 @@
+package com.greenbowl.greenbowlserver.user.configuration;
+
+import com.greenbowl.greenbowlserver.common.application.aop.LoggingAspect;
+import com.greenbowl.greenbowlserver.common.domain.excpeption.GlobalExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({LoggingAspect.class, GlobalExceptionHandler.class})
+public class CommonConfig {
+}

--- a/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/exception/ExceptionMessage.java
+++ b/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/exception/ExceptionMessage.java
@@ -1,0 +1,6 @@
+package com.greenbowl.greenbowlserver.user.exception;
+
+public class ExceptionMessage {
+    public static final String RECIPE_ID_NOT_FOUND_EXCEPTION_MESSAGE = "해당하는 레시피를 찾을 수 없습니다. 전송된 ID: %d";
+    public static final String RECIPE_NAME_NOT_FOUND_EXCEPTION_MESSAGE = "해당하는 레시피를 찾을 수 없습니다. 전송된 레시피명: %s";
+}

--- a/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/exception/UserNotFoundException.java
+++ b/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package com.greenbowl.greenbowlserver.user.exception;
+
+import javax.persistence.EntityNotFoundException;
+
+public class UserNotFoundException extends EntityNotFoundException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/port/in/AuthenticationResult.java
+++ b/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/port/in/AuthenticationResult.java
@@ -1,0 +1,27 @@
+package com.greenbowl.greenbowlserver.user.port.in;
+
+import com.greenbowl.greenbowlserver.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class AuthenticationResult {
+    private final Long userId;
+    private final LocalDateTime lastLoggedInAt;
+    private final boolean isNewUser;
+    private final String accessToken;
+
+    public static AuthenticationResult from(User user, boolean isNewUser, String accessToken) {
+        return AuthenticationResult.builder()
+                .userId(user.getId())
+                .isNewUser(isNewUser)
+                .lastLoggedInAt(user.getLastLoggedInAt())
+                .accessToken(accessToken)
+                .build();
+    }
+}

--- a/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/port/in/command/SignInCommand.java
+++ b/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/port/in/command/SignInCommand.java
@@ -1,0 +1,16 @@
+package com.greenbowl.greenbowlserver.user.port.in.command;
+
+import lombok.Getter;
+
+@Getter
+public class SignInCommand {
+    private final String email;
+
+    private SignInCommand(String email) {
+        this.email = email;
+    }
+
+    public static SignInCommand of(String email) {
+        return new SignInCommand(email);
+    }
+}

--- a/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/port/in/usecase/AuthenticationUseCase.java
+++ b/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/port/in/usecase/AuthenticationUseCase.java
@@ -1,0 +1,8 @@
+package com.greenbowl.greenbowlserver.user.port.in.usecase;
+
+import com.greenbowl.greenbowlserver.user.port.in.AuthenticationResult;
+import com.greenbowl.greenbowlserver.user.port.in.command.SignInCommand;
+
+public interface AuthenticationUseCase {
+    AuthenticationResult signInUser(SignInCommand signInCommand);
+}

--- a/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/port/in/usecase/GetUserUseCase.java
+++ b/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/port/in/usecase/GetUserUseCase.java
@@ -1,0 +1,13 @@
+package com.greenbowl.greenbowlserver.user.port.in.usecase;
+
+import com.greenbowl.greenbowlserver.user.domain.User;
+
+import java.util.Optional;
+
+public interface GetUserUseCase {
+    boolean isSignedUp(String email);
+
+    User getUser(Long userId);
+
+    User getUser(String email);
+}

--- a/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/port/in/usecase/SignUpUseCase.java
+++ b/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/port/in/usecase/SignUpUseCase.java
@@ -1,0 +1,8 @@
+package com.greenbowl.greenbowlserver.user.port.in.usecase;
+
+import com.greenbowl.greenbowlserver.user.domain.User;
+import com.greenbowl.greenbowlserver.user.port.in.command.SignInCommand;
+
+public interface SignUpUseCase {
+    User createUser(SignInCommand signInCommand);
+}

--- a/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/port/out/AuthenticationPort.java
+++ b/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/port/out/AuthenticationPort.java
@@ -1,0 +1,14 @@
+package com.greenbowl.greenbowlserver.user.port.out;
+
+import com.greenbowl.greenbowlserver.user.domain.User;
+import org.springframework.security.core.Authentication;
+
+public interface AuthenticationPort {
+    String generateAccessToken(User user);
+
+    Authentication getAuthentication(String token);
+
+    String parseUserId(String accessToken);
+
+    boolean validateToken(String accessToken);
+}

--- a/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/port/out/FindUserPort.java
+++ b/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/port/out/FindUserPort.java
@@ -1,0 +1,13 @@
+package com.greenbowl.greenbowlserver.user.port.out;
+
+import com.greenbowl.greenbowlserver.user.domain.User;
+
+import java.util.Optional;
+
+public interface FindUserPort {
+    boolean isUserExists(String email);
+
+    Optional<User> findById(Long userId);
+
+    Optional<User> findByEmail(String email);
+}

--- a/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/port/out/SignUpPort.java
+++ b/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/port/out/SignUpPort.java
@@ -1,0 +1,7 @@
+package com.greenbowl.greenbowlserver.user.port.out;
+
+import com.greenbowl.greenbowlserver.user.domain.User;
+
+public interface SignUpPort {
+    User saveUser(User user);
+}

--- a/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/service/AuthenticationService.java
+++ b/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/service/AuthenticationService.java
@@ -1,0 +1,40 @@
+package com.greenbowl.greenbowlserver.user.service;
+
+import com.greenbowl.greenbowlserver.common.application.UseCase;
+import com.greenbowl.greenbowlserver.user.domain.User;
+import com.greenbowl.greenbowlserver.user.port.in.AuthenticationResult;
+import com.greenbowl.greenbowlserver.user.port.in.command.SignInCommand;
+import com.greenbowl.greenbowlserver.user.port.in.usecase.AuthenticationUseCase;
+import com.greenbowl.greenbowlserver.user.port.in.usecase.GetUserUseCase;
+import com.greenbowl.greenbowlserver.user.port.in.usecase.SignUpUseCase;
+import com.greenbowl.greenbowlserver.user.port.out.AuthenticationPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@RequiredArgsConstructor
+@UseCase
+@Transactional(isolation = READ_COMMITTED, timeout = 15)
+public class AuthenticationService implements AuthenticationUseCase {
+    private final GetUserUseCase getUserUseCase;
+    private final SignUpUseCase signUpUseCase;
+    private final AuthenticationPort authenticationPort;
+
+    @Override
+    public AuthenticationResult signInUser(SignInCommand signInCommand) {
+        boolean isUserExists = getUserUseCase.isSignedUp(signInCommand.getEmail());
+        User signedUpUser = loadUser(isUserExists, signInCommand);
+        String accessToken = authenticationPort.generateAccessToken(signedUpUser);
+
+        return AuthenticationResult.from(signedUpUser, !isUserExists, accessToken);
+    }
+
+    private User loadUser(boolean isUserExists, SignInCommand signInCommand) {
+        if (isUserExists) {
+            return getUserUseCase.getUser(signInCommand.getEmail());
+        }
+
+        return signUpUseCase.createUser(signInCommand);
+    }
+}

--- a/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/service/GetUserService.java
+++ b/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/service/GetUserService.java
@@ -1,0 +1,50 @@
+package com.greenbowl.greenbowlserver.user.service;
+
+import com.greenbowl.greenbowlserver.common.application.UseCase;
+import com.greenbowl.greenbowlserver.user.domain.User;
+import com.greenbowl.greenbowlserver.user.domain.security.CustomUserDetails;
+import com.greenbowl.greenbowlserver.user.exception.UserNotFoundException;
+import com.greenbowl.greenbowlserver.user.port.in.usecase.GetUserUseCase;
+import com.greenbowl.greenbowlserver.user.port.out.FindUserPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.greenbowl.greenbowlserver.user.domain.exception.message.NotFoundExceptionMessage.EMAIL_NOT_FOUND_EXCEPTION_MESSAGE;
+import static com.greenbowl.greenbowlserver.user.domain.exception.message.NotFoundExceptionMessage.USER_ID_NOT_FOUND_EXCEPTION_MESSAGE;
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@RequiredArgsConstructor
+@UseCase
+@Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 10)
+public class GetUserService implements UserDetailsService, GetUserUseCase {
+    private final FindUserPort findUserPort;
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        return new CustomUserDetails(getUser(Long.parseLong(userId)));
+    }
+
+    @Override
+    public boolean isSignedUp(String email) {
+        return findUserPort.isUserExists(email);
+    }
+
+    @Override
+    public User getUser(Long userId) {
+        return findUserPort.findById(userId)
+                .orElseThrow(
+                        () -> new UserNotFoundException(String.format(USER_ID_NOT_FOUND_EXCEPTION_MESSAGE, userId))
+                );
+    }
+
+    @Override
+    public User getUser(String email) {
+        return findUserPort.findByEmail(email)
+                .orElseThrow(
+                        () -> new UserNotFoundException(String.format(EMAIL_NOT_FOUND_EXCEPTION_MESSAGE, email))
+                );
+    }
+}

--- a/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/service/SignUpService.java
+++ b/user-service/user-application/src/main/java/com/greenbowl/greenbowlserver/user/service/SignUpService.java
@@ -1,0 +1,23 @@
+package com.greenbowl.greenbowlserver.user.service;
+
+import com.greenbowl.greenbowlserver.common.application.UseCase;
+import com.greenbowl.greenbowlserver.user.domain.User;
+import com.greenbowl.greenbowlserver.user.port.in.command.SignInCommand;
+import com.greenbowl.greenbowlserver.user.port.in.usecase.SignUpUseCase;
+import com.greenbowl.greenbowlserver.user.port.out.SignUpPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.SERIALIZABLE;
+
+@RequiredArgsConstructor
+@UseCase
+@Transactional(isolation = SERIALIZABLE, propagation = Propagation.REQUIRES_NEW)
+public class SignUpService implements SignUpUseCase {
+    private final SignUpPort signUpPort;
+
+    public User createUser(SignInCommand signInCommand) {
+        return signUpPort.saveUser(User.of(signInCommand.getEmail()));
+    }
+}

--- a/user-service/user-domain/src/main/java/com/greenbowl/greenbowlserver/user/configuration/CommonConfig.java
+++ b/user-service/user-domain/src/main/java/com/greenbowl/greenbowlserver/user/configuration/CommonConfig.java
@@ -1,0 +1,11 @@
+package com.greenbowl.greenbowlserver.user.configuration;
+
+import com.greenbowl.greenbowlserver.common.application.aop.LoggingAspect;
+import com.greenbowl.greenbowlserver.common.domain.excpeption.GlobalExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({LoggingAspect.class, GlobalExceptionHandler.class})
+public class CommonConfig {
+}

--- a/user-service/user-domain/src/main/java/com/greenbowl/greenbowlserver/user/domain/User.java
+++ b/user-service/user-domain/src/main/java/com/greenbowl/greenbowlserver/user/domain/User.java
@@ -1,0 +1,39 @@
+package com.greenbowl.greenbowlserver.user.domain;
+
+import com.greenbowl.greenbowlserver.user.domain.wrapper.Email;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.security.AuthProvider;
+import java.time.LocalDateTime;
+
+@Getter
+public class User {
+    private Long id;
+    private Email email;
+    private AuthProvider authProvider;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private LocalDateTime lastLoggedInAt;
+
+    private User(Email email) {
+        this.email = email;
+    }
+
+    @Builder
+    private User(
+            Long id, Email email, AuthProvider authProvider,
+            LocalDateTime createdAt, LocalDateTime modifiedAt, LocalDateTime lastLoggedInAt
+    ) {
+        this.id = id;
+        this.email = email;
+        this.authProvider = authProvider;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+        this.lastLoggedInAt = lastLoggedInAt;
+    }
+
+    public static User of(String email) {
+        return new User(Email.of(email));
+    }
+}

--- a/user-service/user-domain/src/main/java/com/greenbowl/greenbowlserver/user/domain/exception/message/BlankExceptionMessage.java
+++ b/user-service/user-domain/src/main/java/com/greenbowl/greenbowlserver/user/domain/exception/message/BlankExceptionMessage.java
@@ -1,0 +1,7 @@
+package com.greenbowl.greenbowlserver.user.domain.exception.message;
+
+public class BlankExceptionMessage {
+    public static final String EMAIL_NO_VALUE_EXCEPTION = "이메일 주소는 필수값입니다.";
+    public static final String USERNAME_NO_VALUE_EXCEPTION = "사용자 이름은 필수값입니다.";
+    public static final String FULL_NAME_NO_VALUE_EXCEPTION = "성명은 필수값입니다.";
+}

--- a/user-service/user-domain/src/main/java/com/greenbowl/greenbowlserver/user/domain/exception/message/InvalidExceptionMessage.java
+++ b/user-service/user-domain/src/main/java/com/greenbowl/greenbowlserver/user/domain/exception/message/InvalidExceptionMessage.java
@@ -1,0 +1,13 @@
+package com.greenbowl.greenbowlserver.user.domain.exception.message;
+
+public class InvalidExceptionMessage {
+    public static final String INVALID_EMAIL_EXCEPTION = "이메일 주소 형식이 잘못되었습니다. 예: abcd@abc.com";
+
+    public static final String INVALID_USERNAME_EXCEPTION
+            = "아이디는 4~16자의 영소문자와 숫자만으로 구성되어야 합니다. 예: tester1";
+
+    public static final String INVALID_PASSWORD_EXCEPTION
+            = "비밀번호는 8자 이상이어야 하며, 하나 이상의 대문자와 소문자, 숫자, 특수문자를 포함해야 합니다. 예: Test1234!@";
+
+    public static final String INVALID_FULL_NAME_EXCEPTION = "성명은 2~5자의 한글만 가능합니다. 예: 홍길동";
+}

--- a/user-service/user-domain/src/main/java/com/greenbowl/greenbowlserver/user/domain/exception/message/NotFoundExceptionMessage.java
+++ b/user-service/user-domain/src/main/java/com/greenbowl/greenbowlserver/user/domain/exception/message/NotFoundExceptionMessage.java
@@ -1,0 +1,6 @@
+package com.greenbowl.greenbowlserver.user.domain.exception.message;
+
+public class NotFoundExceptionMessage {
+    public static final String USER_ID_NOT_FOUND_EXCEPTION_MESSAGE = "해당 회원이 존재하지 않습니다. ID: %s";
+    public static final String EMAIL_NOT_FOUND_EXCEPTION_MESSAGE = "해당 회원이 존재하지 않습니다. 이메일 주소: %s";
+}

--- a/user-service/user-domain/src/main/java/com/greenbowl/greenbowlserver/user/domain/security/CustomUserDetails.java
+++ b/user-service/user-domain/src/main/java/com/greenbowl/greenbowlserver/user/domain/security/CustomUserDetails.java
@@ -1,0 +1,48 @@
+package com.greenbowl.greenbowlserver.user.domain.security;
+
+import com.greenbowl.greenbowlserver.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(user.getId());
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/user-service/user-domain/src/main/java/com/greenbowl/greenbowlserver/user/domain/wrapper/Email.java
+++ b/user-service/user-domain/src/main/java/com/greenbowl/greenbowlserver/user/domain/wrapper/Email.java
@@ -1,0 +1,58 @@
+package com.greenbowl.greenbowlserver.user.domain.wrapper;
+
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+import static com.greenbowl.greenbowlserver.user.domain.exception.message.BlankExceptionMessage.EMAIL_NO_VALUE_EXCEPTION;
+import static com.greenbowl.greenbowlserver.user.domain.exception.message.InvalidExceptionMessage.INVALID_EMAIL_EXCEPTION;
+
+
+public class Email {
+    private final String email;
+    private static final String EMAIL_PATTERN = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+
+    private Email(String email) {
+        this.email = email;
+    }
+
+    public static Email of(String email) {
+        validate(email);
+
+        return new Email(email);
+    }
+
+    String getValue() {
+        return email;
+    }
+
+    private static void validate(String email) {
+        checkEmailIsNotBlank(email);
+        checkEmailPattern(email);
+    }
+
+    private static void checkEmailIsNotBlank(String email) {
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException(EMAIL_NO_VALUE_EXCEPTION);
+        }
+    }
+
+    private static void checkEmailPattern(String email) {
+        if (!email.matches(EMAIL_PATTERN)) {
+            throw new IllegalArgumentException(INVALID_EMAIL_EXCEPTION);
+        }
+    }
+
+    @Converter
+    public static class EmailConverter implements AttributeConverter<Email, String> {
+        @Override
+        public String convertToDatabaseColumn(Email email) {
+            return email == null ? null : email.email;
+        }
+
+        @Override
+        public Email convertToEntityAttribute(String email) {
+            return email == null ? null : new Email(email);
+        }
+    }
+}

--- a/user-service/user-domain/src/main/java/com/greenbowl/greenbowlserver/user/domain/wrapper/WrapperAccessor.java
+++ b/user-service/user-domain/src/main/java/com/greenbowl/greenbowlserver/user/domain/wrapper/WrapperAccessor.java
@@ -1,0 +1,7 @@
+package com.greenbowl.greenbowlserver.user.domain.wrapper;
+
+public class WrapperAccessor {
+    public static String getEmailValue(Email email) {
+        return email.getValue();
+    }
+}


### PR DESCRIPTION
## resolve [TEAM15-525](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/milestones/8mIrW1uBe5GiqN5gw_heA)
## resolve #73

## 작업내용
- 로그인 요청
- 로그인 비즈니스 로직
    - 회원 이메일 주소가 존재하지 않는 경우 회원 엔티티 생성 및 튜플 저장
    - 회원 이메일 주소가 존재하는 경우 기존 회원 정보 조회
    - 회원 ID와 이메일 주소를 기반으로 한 페이로드 생성
    - RSA 암호화 알고리즘 및 Hash 알고리즘을 통한 헤더와 페이로드 서명
    - 로그인 비즈니스 로직 - 게이트웨이의 인증 및 인가를 위한 공개키 전달
    - 201(신규 회원 로그인) 또는 200(기존 회원 로그인) status code 응답

## 배포
- [x] 성공
- [ ] 실패