### PR TITLE
[TEAM15-470] feat(recipe): 클라이언트는 레시피 서버를 통해 요청한 레시피 정보를 삭제할 수 있다

### DIFF
--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/controller/CancelBookmarkRecipeController.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/controller/CancelBookmarkRecipeController.java
@@ -1,0 +1,25 @@
+package com.greenbowl.greenbowlserver.recipe.adapter.in.web.controller;
+
+import com.greenbowl.greenbowlserver.common.adapter.in.WebAdapter;
+import com.greenbowl.greenbowlserver.recipe.port.in.usecase.RemoveRecipeUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+public class CancelBookmarkRecipeController {
+    private final RemoveRecipeUseCase removeRecipeUseCase;
+
+    @DeleteMapping()
+    public ResponseEntity<Void> cancelRecipe(@RequestParam(value = "name") String name) {
+        removeRecipeUseCase.removeRecipe(name);
+
+        return ResponseEntity.status(NO_CONTENT).build();
+    }
+}

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeJpaEntity.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeJpaEntity.java
@@ -106,4 +106,8 @@ public class RecipeJpaEntity extends BaseGeneralEntity {
                 ))
                 .collect(Collectors.toList());
     }
+
+    public void delete() {
+        deleteEntity();
+    }
 }

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipePersistenceAdapter.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipePersistenceAdapter.java
@@ -3,6 +3,7 @@ package com.greenbowl.greenbowlserver.recipe.adapter.out.persistence.recipe;
 import com.greenbowl.greenbowlserver.common.adapter.out.PersistenceAdapter;
 import com.greenbowl.greenbowlserver.recipe.adapter.out.mapper.RecipeJpaEntityToDomainMapper;
 import com.greenbowl.greenbowlserver.recipe.domain.Recipe;
+import com.greenbowl.greenbowlserver.recipe.port.out.DeleteRecipePort;
 import com.greenbowl.greenbowlserver.recipe.port.out.FindRecipePort;
 import com.greenbowl.greenbowlserver.recipe.port.out.SaveRecipePort;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +15,7 @@ import java.util.stream.Collectors;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class RecipePersistenceAdapter implements SaveRecipePort, FindRecipePort {
+public class RecipePersistenceAdapter implements SaveRecipePort, FindRecipePort, DeleteRecipePort {
     private final RecipeRepository recipeRepository;
 
     @Override
@@ -49,5 +50,17 @@ public class RecipePersistenceAdapter implements SaveRecipePort, FindRecipePort 
     @Override
     public Optional<Recipe> findById(Long id) {
         return RecipeJpaEntityToDomainMapper.mapToOptionalDomainEntity(recipeRepository.findByIdAndDeleteYnFalse(id));
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        RecipeJpaEntity recipeJpaEntity = recipeRepository.findByIdAndDeleteYnFalse(id);
+        recipeJpaEntity.delete();
+    }
+
+    @Override
+    public void deleteByName(String name) {
+        List<RecipeJpaEntity> recipeJpaEntities = recipeRepository.findByNameAndDeleteYnFalse(name);
+        recipeJpaEntities.forEach(RecipeJpaEntity::delete);
     }
 }

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeRepository.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeRepository.java
@@ -1,5 +1,6 @@
 package com.greenbowl.greenbowlserver.recipe.adapter.out.persistence.recipe;
 
+import com.greenbowl.greenbowlserver.recipe.domain.Recipe;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,6 +11,8 @@ public interface RecipeRepository extends JpaRepository<RecipeJpaEntity, Long> {
     List<RecipeJpaEntity> findByUserIdAndDeleteYnFalseOrderByModifiedAtDesc(Long userId);
     */
     List<RecipeJpaEntity> findByDeleteYnFalseOrderByModifiedAtDesc();
+
+    List<Recipe> existsByNameAndDeleteYnFalse(String name);
 
     List<RecipeJpaEntity> findByNameAndDeleteYnFalse(String name);
 

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/usecase/RemoveRecipeUseCase.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/usecase/RemoveRecipeUseCase.java
@@ -1,0 +1,5 @@
+package com.greenbowl.greenbowlserver.recipe.port.in.usecase;
+
+public interface RemoveRecipeUseCase {
+    void removeRecipe(String name);
+}

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/out/DeleteRecipePort.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/out/DeleteRecipePort.java
@@ -1,0 +1,7 @@
+package com.greenbowl.greenbowlserver.recipe.port.out;
+
+public interface DeleteRecipePort {
+    void deleteById(Long id);
+
+    void deleteByName(String name);
+}

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/service/RemoveRecipeService.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/service/RemoveRecipeService.java
@@ -1,0 +1,33 @@
+package com.greenbowl.greenbowlserver.recipe.service;
+
+import com.greenbowl.greenbowlserver.common.application.UseCase;
+import com.greenbowl.greenbowlserver.recipe.domain.Recipe;
+import com.greenbowl.greenbowlserver.recipe.port.in.usecase.GetRecipeUseCase;
+import com.greenbowl.greenbowlserver.recipe.port.in.usecase.RemoveRecipeUseCase;
+import com.greenbowl.greenbowlserver.recipe.port.out.DeleteRecipePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_UNCOMMITTED;
+
+@RequiredArgsConstructor
+@UseCase
+@Transactional(isolation = READ_UNCOMMITTED, timeout = 10)
+public class RemoveRecipeService implements RemoveRecipeUseCase {
+    private final GetRecipeUseCase getRecipeUseCase;
+    private final DeleteRecipePort deleteRecipePort;
+
+    @Override
+    public void removeRecipe(String name) {
+        List<Recipe> recipes = getRecipeUseCase.getRecipes(name);
+
+        if (recipes.size() == 1) {
+            deleteRecipePort.deleteById(recipes.get(0).getId());
+            return;
+        }
+
+        deleteRecipePort.deleteByName(name);
+    }
+}


### PR DESCRIPTION
## resolve [TEAM15-470](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/milestones/pW8pfa7XT08z8a2rYmPkH)
## resolve #54

## 작업내용
- 레시피 정보 삭제 요청
- 레시피 정보 삭제 비즈니스 로직
- 데이터베이스에서 레시피 정보 논리적 삭제
- 204 status code 응답

## 배포
- [x] 성공
- [ ] 실패