### PR TITLE
[TEAM15-546] feat(recipe): 레시피 서버의 회원 북마크 추가 및 북마크 목록 조회 기능에 실제 회원 ID 적용

### DIFF
--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/controller/AddBookmarkRecipeController.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/controller/AddBookmarkRecipeController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.springframework.http.HttpStatus.CREATED;
@@ -20,20 +21,22 @@ public class AddBookmarkRecipeController {
     private final CreateRecipeUseCase createRecipeUseCase;
 
     @PostMapping()
-    public ResponseEntity<Void> addRecipe(@RequestBody AddRecipeRequest addRecipeRequest) {
-        // TODO: 회원 기능 구현 후 JWT Payload 디코딩을 통한 실제 회원 ID로 대체
-        String userId = "1";
-
+    public ResponseEntity<Void> addRecipe(
+            @RequestBody AddRecipeRequest addRecipeRequest,
+            @RequestHeader(value = "userId", required = false, defaultValue = "1") String userId
+    ) {
         createRecipeUseCase.createRecipe(RecipeRequestToCommandMapper.mapToCommand(userId, addRecipeRequest));
 
-        return ResponseEntity.status(CREATED).build();
+        return ResponseEntity.status(CREATED).
+
+                build();
     }
 
     @PostMapping("/detailed")
-    public ResponseEntity<Void> addRecipe(@RequestBody AddDetailedRecipeRequest addDetailedRecipeRequest) {
-        // TODO: 회원 기능 구현 후 JWT Payload 디코딩을 통한 실제 회원 ID로 대체
-        String userId = "1";
-
+    public ResponseEntity<Void> addRecipe(
+            @RequestBody AddDetailedRecipeRequest addDetailedRecipeRequest,
+            @RequestHeader(value = "userId", required = false, defaultValue = "1") String userId
+    ) {
         createRecipeUseCase.createRecipe(RecipeRequestToCommandMapper.mapToCommand(userId, addDetailedRecipeRequest));
 
         return ResponseEntity.status(CREATED).build();

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/controller/GetBookmarkRecipeController.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/controller/GetBookmarkRecipeController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -24,10 +25,9 @@ public class GetBookmarkRecipeController {
     private final GetRecipeUseCase getRecipeUseCase;
 
     @GetMapping()
-    public ResponseEntity<List<GetRecipeResponse>> getUserRecipes() {
-        // TODO: 회원 기능 구현 후 JWT Payload 디코딩을 통한 실제 회원 ID로 대체
-        String userId = "1";
-
+    public ResponseEntity<List<GetRecipeResponse>> getUserRecipes(
+            @RequestHeader(value = "userId", required = false, defaultValue = "1") String userId
+    ) {
         List<Recipe> recipes = getRecipeUseCase.getRecipes(FormatConverter.parseToLong(userId));
 
         return ResponseEntity.status(OK).body(

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/mapper/RecipeJpaEntityToDomainMapper.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/mapper/RecipeJpaEntityToDomainMapper.java
@@ -18,6 +18,7 @@ public class RecipeJpaEntityToDomainMapper {
                 .filter(FormatValidator::hasValue)
                 .map(entity -> Recipe.of(
                         entity.getId(),
+                        entity.getUserId(),
                         entity.getName(),
                         entity.getImageUrl(),
                         entity.getCookingTime(),
@@ -34,6 +35,7 @@ public class RecipeJpaEntityToDomainMapper {
     public static Recipe mapToDomainEntity(RecipeJpaEntity recipeJpaEntity) {
         return Recipe.of(
                 recipeJpaEntity.getId(),
+                recipeJpaEntity.getUserId(),
                 recipeJpaEntity.getName(),
                 recipeJpaEntity.getImageUrl(),
                 recipeJpaEntity.getCookingTime(),

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeJpaEntity.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeJpaEntity.java
@@ -20,6 +20,8 @@ import static javax.persistence.CascadeType.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class RecipeJpaEntity extends BaseGeneralEntity {
+    private Long userId;
+
     @Column(nullable = false, length = 255)
     private String name;
 
@@ -53,10 +55,11 @@ public class RecipeJpaEntity extends BaseGeneralEntity {
 
     @Builder
     private RecipeJpaEntity(
-            String name, String imageUrl, short cookingTime, short calories, String oneLineIntroduction,
-            List<RecipeIngredientJpaEntity> recipeIngredientJpaEntities, String introduction,
-            EmbeddableNutrition embeddableNutrition
+            Long userId, String name, String imageUrl, short cookingTime, short calories,
+            String oneLineIntroduction, List<RecipeIngredientJpaEntity> recipeIngredientJpaEntities,
+            String introduction, EmbeddableNutrition embeddableNutrition
     ) {
+        this.userId = userId;
         this.name = name;
         this.imageUrl = imageUrl;
         this.cookingTime = cookingTime;
@@ -72,6 +75,7 @@ public class RecipeJpaEntity extends BaseGeneralEntity {
 
         if (FormatValidator.hasValue(recipeOneLineIntroduction)) {
             RecipeJpaEntity recipeJpaEntity = RecipeJpaEntity.builder()
+                    .userId(recipe.getUserId())
                     .name(recipe.getName())
                     .imageUrl(recipe.getImageUrl())
                     .cookingTime(recipe.getCookingTime())
@@ -89,6 +93,7 @@ public class RecipeJpaEntity extends BaseGeneralEntity {
         }
 
         return RecipeJpaEntity.builder()
+                .userId(recipe.getUserId())
                 .name(recipe.getName())
                 .imageUrl(recipe.getImageUrl())
                 .cookingTime(recipe.getCookingTime())

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipePersistenceAdapter.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipePersistenceAdapter.java
@@ -25,15 +25,7 @@ public class RecipePersistenceAdapter implements SaveRecipePort, FindRecipePort,
 
     @Override
     public List<Recipe> findByUserId(Long userId) {
-        /*
-        TODO: 회원 기능 구현 후 회원 ID 기반 조회 적용
         return recipeRepository.findByUserIdAndDeleteYnFalseOrderByModifiedAtDesc(userId)
-                .stream()
-                .map(RecipeJpaEntityToDomainMapper::mapToDomainEntity)
-                .collect(Collectors.toList());
-         */
-
-        return recipeRepository.findByDeleteYnFalseOrderByModifiedAtDesc()
                 .stream()
                 .map(RecipeJpaEntityToDomainMapper::mapToDomainEntity)
                 .collect(Collectors.toList());

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeRepository.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeRepository.java
@@ -6,11 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface RecipeRepository extends JpaRepository<RecipeJpaEntity, Long> {
-    /*
-    TODO: 회원 기능 구현 후 회원 ID 기반 조회 적용
     List<RecipeJpaEntity> findByUserIdAndDeleteYnFalseOrderByModifiedAtDesc(Long userId);
-    */
-    List<RecipeJpaEntity> findByDeleteYnFalseOrderByModifiedAtDesc();
 
     List<Recipe> existsByNameAndDeleteYnFalse(String name);
 

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/mapper/RecipeCommandToDomainMapper.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/mapper/RecipeCommandToDomainMapper.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 public class RecipeCommandToDomainMapper {
     public static Recipe mapToDomainEntity(CreateRecipeCommand createRecipeCommand) {
         return Recipe.of(
+                createRecipeCommand.getUserId(),
                 createRecipeCommand.getName(),
                 createRecipeCommand.getImageUrl(),
                 createRecipeCommand.getCookingTime(),
@@ -21,6 +22,7 @@ public class RecipeCommandToDomainMapper {
 
     public static Recipe mapToDomainEntity(CreateDetailedRecipeCommand createDetailedRecipeCommand) {
         return Recipe.of(
+                createDetailedRecipeCommand.getUserId(),
                 createDetailedRecipeCommand.getName(),
                 createDetailedRecipeCommand.getImageUrl(),
                 createDetailedRecipeCommand.getCookingTime(),

--- a/recipe-service/recipe-domain/src/main/java/com/greenbowl/greenbowlserver/recipe/domain/Recipe.java
+++ b/recipe-service/recipe-domain/src/main/java/com/greenbowl/greenbowlserver/recipe/domain/Recipe.java
@@ -9,6 +9,7 @@ import java.util.List;
 @Getter
 public class Recipe {
     private Long id;
+    private Long userId;
     private String name;
     private String imageUrl;
     private short cookingTime;
@@ -22,11 +23,12 @@ public class Recipe {
 
     @Builder
     private Recipe(
-            Long id, String name, String imageUrl, short cookingTime, short calories,
+            Long id, Long userId, String name, String imageUrl, short cookingTime, short calories,
             String oneLineIntroduction, List<RecipeIngredient> recipeIngredients, String introduction,
             Nutrition nutrition, LocalDateTime createdAt, LocalDateTime modifiedAt
     ) {
         this.id = id;
+        this.userId = userId;
         this.name = name;
         this.imageUrl = imageUrl;
         this.cookingTime = cookingTime;
@@ -39,8 +41,9 @@ public class Recipe {
         this.modifiedAt = modifiedAt;
     }
 
-    public static Recipe of(String name, String imageUrl, short cookingTime, short calories) {
+    public static Recipe of(Long userId, String name, String imageUrl, short cookingTime, short calories) {
         return Recipe.builder()
+                .userId(userId)
                 .name(name)
                 .imageUrl(imageUrl)
                 .cookingTime(cookingTime)
@@ -49,10 +52,11 @@ public class Recipe {
     }
 
     public static Recipe of(
-            String name, String imageUrl, short cookingTime, short calories, String oneLineIntroduction,
+            Long userId, String name, String imageUrl, short cookingTime, short calories, String oneLineIntroduction,
             List<RecipeIngredient> recipeIngredients, String introduction, Nutrition nutrition
     ) {
         return Recipe.builder()
+                .userId(userId)
                 .name(name)
                 .imageUrl(imageUrl)
                 .cookingTime(cookingTime)
@@ -65,12 +69,13 @@ public class Recipe {
     }
 
     public static Recipe of(
-            Long id, String name, String imageUrl, short cookingTime, short calories, String oneLineIntroduction,
+            Long id, Long userId, String name, String imageUrl, short cookingTime, short calories, String oneLineIntroduction,
             List<RecipeIngredient> recipeIngredients, String introduction, Nutrition nutrition,
             LocalDateTime createdAt, LocalDateTime modifiedAt
     ) {
         return Recipe.builder()
                 .id(id)
+                .userId(userId)
                 .name(name)
                 .imageUrl(imageUrl)
                 .cookingTime(cookingTime)

--- a/user-service/user-adapters/src/main/resources/application.yml
+++ b/user-service/user-adapters/src/main/resources/application.yml
@@ -25,7 +25,7 @@ spring:
     serialization:
       fail-on-empty-beans: false
   jwt:
-    secret: key
+    secret: ${GREENBOWL_JWT_SECRET_KEY}
   mvc:
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER


### PR DESCRIPTION
## resolve [TEAM15-546](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/milestones/Uut_GFtTrAclzqDawKPlX)
## resolve #90

## 작업내용
- 게이트웨이에서 토큰의 payload에서 추출한 userId 수신
- 레시피 엔티티에 회원 ID 속성 추가
- 데이터베이스에 기본 레시피 튜플 저장 시 회원 ID 정보 추가
- 데이터베이스에 상세 레시피 튜플 저장 시 회원 ID 정보 추가
- 데이터베이스에서 회원 북마크 목록 조회 시 userId 기반의 북마크 목록 조회

## 배포
- [x] 성공
- [ ] 실패
