### PR TITLE
[TEAM15-556] feat(recipe): 클라이언트는 레시피 서버를 통해 요청한 ID를 가진 레시피 정보를 삭제할 수 있다

### DIFF
--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/controller/CancelBookmarkRecipeController.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/controller/CancelBookmarkRecipeController.java
@@ -1,15 +1,19 @@
 package com.greenbowl.greenbowlserver.recipe.adapter.in.web.controller;
 
 import com.greenbowl.greenbowlserver.common.adapter.in.WebAdapter;
+import com.greenbowl.greenbowlserver.common.utility.FormatConverter;
 import com.greenbowl.greenbowlserver.recipe.port.in.usecase.RemoveRecipeUseCase;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.greenbowl.greenbowlserver.common.utility.ApiConstant.ID_EXAMPLE;
+import static com.greenbowl.greenbowlserver.recipe.adapter.in.web.utility.ApiConstant.RECIPE_ID;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 @WebAdapter
@@ -18,15 +22,30 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 public class CancelBookmarkRecipeController {
     private final RemoveRecipeUseCase removeRecipeUseCase;
 
-    private static final String DELETE_BOOKMARKED_RECIPE = "회원이 북마크에 등록한 레시피 삭제";
-    private static final String DELETE_BOOKMARKED_RECIPE_DESCRIPTION
+    private static final String DELETE_BOOKMARKED_BY_ID_RECIPE = "레시피 ID를 통해 회원이 북마크에 등록한 레시피 삭제";
+    private static final String DELETE_BOOKMARKED_RECIPE_BY_ID_DESCRIPTION
+            = "레시피 ID를 입력해 북마크에 등록된 레시피를 삭제할 수 있습니다.";
+
+    private static final String DELETE_BOOKMARKED_BY_NAME_RECIPE = "레시피 이름을 통해 회원이 북마크에 등록한 레시피 삭제";
+    private static final String DELETE_BOOKMARKED_RECIPE_BY_NAME_DESCRIPTION
             = "레시피 이름을 입력해 북마크에 등록된 레시피를 삭제할 수 있습니다.";
     private static final String RECIPE_NAME = "레시피 이름";
     private static final String RECIPE_NAME_EXAMPLE = "된장찌개";
 
-    @ApiOperation(value = DELETE_BOOKMARKED_RECIPE, notes = DELETE_BOOKMARKED_RECIPE_DESCRIPTION)
+    @ApiOperation(value = DELETE_BOOKMARKED_BY_ID_RECIPE, notes = DELETE_BOOKMARKED_RECIPE_BY_ID_DESCRIPTION)
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> cancelRecipeById(
+            @ApiParam(value = RECIPE_ID, example = ID_EXAMPLE)
+            @PathVariable(value = "id") String id
+    ) {
+        removeRecipeUseCase.removeRecipe(FormatConverter.parseToLong(id));
+
+        return ResponseEntity.status(NO_CONTENT).build();
+    }
+
+    @ApiOperation(value = DELETE_BOOKMARKED_BY_NAME_RECIPE, notes = DELETE_BOOKMARKED_RECIPE_BY_NAME_DESCRIPTION)
     @DeleteMapping()
-    public ResponseEntity<Void> cancelRecipe(
+    public ResponseEntity<Void> cancelRecipeByName(
             @ApiParam(value = RECIPE_NAME, example = RECIPE_NAME_EXAMPLE)
             @RequestParam(value = "name") String name
     ) {

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/controller/GetBookmarkRecipeController.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/controller/GetBookmarkRecipeController.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 
 import static com.greenbowl.greenbowlserver.common.utility.ApiConstant.ID_EXAMPLE;
 import static com.greenbowl.greenbowlserver.common.utility.ApiConstant.USER_ID;
+import static com.greenbowl.greenbowlserver.recipe.adapter.in.web.utility.ApiConstant.RECIPE_ID;
 import static org.springframework.http.HttpStatus.OK;
 
 @WebAdapter
@@ -34,7 +35,6 @@ public class GetBookmarkRecipeController {
     private static final String GET_BOOKMARKED_RECIPE = "북마크에 등록된 상세 레시피 정보 조회";
     private static final String GET_BOOKMARKED_RECIPE_DESCRIPTION
             = "레시피 ID를 전송해 북마크에 등록된 상세 레시피 정보를 조회할 수 있습니다.";
-    public static final String RECIPE_ID = "레시피 ID";
 
     @ApiOperation(value = GET_USER_BOOKMARKED_RECIPES, notes = GET_USER_BOOKMARKED_RECIPES_DESCRIPTION)
     @GetMapping()

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/utility/ApiConstant.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/utility/ApiConstant.java
@@ -1,0 +1,5 @@
+package com.greenbowl.greenbowlserver.recipe.adapter.in.web.utility;
+
+public class ApiConstant {
+    public static final String RECIPE_ID = "레시피 ID";
+}

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipePersistenceAdapter.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipePersistenceAdapter.java
@@ -24,6 +24,11 @@ public class RecipePersistenceAdapter implements SaveRecipePort, FindRecipePort,
     }
 
     @Override
+    public boolean existsById(Long id) {
+        return recipeRepository.existsByIdAndDeleteYnFalse(id);
+    }
+
+    @Override
     public List<Recipe> findByUserId(Long userId) {
         return recipeRepository.findByUserIdAndDeleteYnFalseOrderByModifiedAtDesc(userId)
                 .stream()

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeRepository.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeRepository.java
@@ -1,6 +1,5 @@
 package com.greenbowl.greenbowlserver.recipe.adapter.out.persistence.recipe;
 
-import com.greenbowl.greenbowlserver.recipe.domain.Recipe;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,7 +7,7 @@ import java.util.List;
 public interface RecipeRepository extends JpaRepository<RecipeJpaEntity, Long> {
     List<RecipeJpaEntity> findByUserIdAndDeleteYnFalseOrderByModifiedAtDesc(Long userId);
 
-    List<Recipe> existsByNameAndDeleteYnFalse(String name);
+    boolean existsByIdAndDeleteYnFalse(Long id);
 
     List<RecipeJpaEntity> findByNameAndDeleteYnFalse(String name);
 

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/configuration/SwaggerConfig.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/configuration/SwaggerConfig.java
@@ -43,8 +43,8 @@ SwaggerConfig {
                 .build()
                 .apiInfo(apiInfo())
                 .securityContexts(Arrays.asList(securityContext()))
-                .securitySchemes(Arrays.asList(apiKey()))
-                .pathMapping("/api/recipes");
+                .securitySchemes(Arrays.asList(apiKey()));
+//                .pathMapping("/api/recipes");
     }
 
     private SecurityContext securityContext() {

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/usecase/GetRecipeUseCase.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/usecase/GetRecipeUseCase.java
@@ -5,6 +5,8 @@ import com.greenbowl.greenbowlserver.recipe.domain.Recipe;
 import java.util.List;
 
 public interface GetRecipeUseCase {
+    boolean isExistent(Long id);
+
     List<Recipe> getRecipes(Long userId);
 
     List<Recipe> getRecipes(String name);

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/usecase/RemoveRecipeUseCase.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/in/usecase/RemoveRecipeUseCase.java
@@ -1,5 +1,7 @@
 package com.greenbowl.greenbowlserver.recipe.port.in.usecase;
 
 public interface RemoveRecipeUseCase {
+    void removeRecipe(Long id);
+
     void removeRecipe(String name);
 }

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/out/FindRecipePort.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/port/out/FindRecipePort.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface FindRecipePort {
+    boolean existsById(Long id);
+
     List<Recipe> findByUserId(Long userId);
 
     List<Recipe> findByName(String name);

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/service/GetRecipeService.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/service/GetRecipeService.java
@@ -22,6 +22,11 @@ public class GetRecipeService implements GetRecipeUseCase {
     private final FindRecipePort findRecipePort;
 
     @Override
+    public boolean isExistent(Long id) {
+        return findRecipePort.existsById(id);
+    }
+
+    @Override
     public List<Recipe> getRecipes(Long userId) {
         return findRecipePort.findByUserId(userId);
     }

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/service/RemoveRecipeService.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/service/RemoveRecipeService.java
@@ -2,6 +2,7 @@ package com.greenbowl.greenbowlserver.recipe.service;
 
 import com.greenbowl.greenbowlserver.common.application.UseCase;
 import com.greenbowl.greenbowlserver.recipe.domain.Recipe;
+import com.greenbowl.greenbowlserver.recipe.exception.RecipeNotFoundException;
 import com.greenbowl.greenbowlserver.recipe.port.in.usecase.GetRecipeUseCase;
 import com.greenbowl.greenbowlserver.recipe.port.in.usecase.RemoveRecipeUseCase;
 import com.greenbowl.greenbowlserver.recipe.port.out.DeleteRecipePort;
@@ -10,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.greenbowl.greenbowlserver.recipe.exception.ExceptionMessage.RECIPE_ID_NOT_FOUND_EXCEPTION_MESSAGE;
 import static org.springframework.transaction.annotation.Isolation.READ_UNCOMMITTED;
 
 @RequiredArgsConstructor
@@ -18,6 +20,16 @@ import static org.springframework.transaction.annotation.Isolation.READ_UNCOMMIT
 public class RemoveRecipeService implements RemoveRecipeUseCase {
     private final GetRecipeUseCase getRecipeUseCase;
     private final DeleteRecipePort deleteRecipePort;
+
+    @Override
+    public void removeRecipe(Long id) {
+        if (getRecipeUseCase.isExistent(id)) {
+            deleteRecipePort.deleteById(id);
+            return;
+        }
+
+        throw new RecipeNotFoundException(String.format(RECIPE_ID_NOT_FOUND_EXCEPTION_MESSAGE, id));
+    }
 
     @Override
     public void removeRecipe(String name) {


### PR DESCRIPTION
## resolve [TEAM15-556](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/milestones/iHljYeqXBAEpINmxb1QV6)
## resolve #99

## 작업내용
- 레시피 정보 삭제 요청
- 레시피 정보 삭제 비즈니스 로직
- 데이터베이스에서 레시피 정보 논리적 삭제
- 204 status code 응답

## 배포
- [x] 성공
- [ ] 실패