### PR TITLE
[TEAM15-245] feat(recommendation): 클라이언트는 Recommendation Service에서 Push된 LLM 스트리밍 데이터를 수신할 수 있다

### DIFF
--- a/common/src/main/java/com/greenbowl/greenbowlserver/common/utility/ApiConstant.java
+++ b/common/src/main/java/com/greenbowl/greenbowlserver/common/utility/ApiConstant.java
@@ -3,4 +3,7 @@ package com.greenbowl.greenbowlserver.common.utility;
 public class ApiConstant {
     public static final String ID_EXAMPLE = "1";
     public static final String USER_ID = "회원 ID";
+
+    public static final String RECIPE_NAME_VALUE = "레시피 이름";
+    public static final String RECIPE_NAME_EXAMPLE = "된장찌개";
 }

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/controller/CancelBookmarkRecipeController.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/controller/CancelBookmarkRecipeController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.greenbowl.greenbowlserver.common.utility.ApiConstant.ID_EXAMPLE;
-import static com.greenbowl.greenbowlserver.recipe.adapter.in.web.utility.ApiConstant.RECIPE_ID;
+import static com.greenbowl.greenbowlserver.recipe.adapter.in.web.utility.ApiConstant.RECIPE_ID_VALUE;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 @WebAdapter
@@ -35,7 +35,7 @@ public class CancelBookmarkRecipeController {
     @ApiOperation(value = DELETE_BOOKMARKED_BY_ID_RECIPE, notes = DELETE_BOOKMARKED_RECIPE_BY_ID_DESCRIPTION)
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> cancelRecipeById(
-            @ApiParam(value = RECIPE_ID, example = ID_EXAMPLE)
+            @ApiParam(value = RECIPE_ID_VALUE, example = ID_EXAMPLE)
             @PathVariable(value = "id") String id
     ) {
         removeRecipeUseCase.removeRecipe(FormatConverter.parseToLong(id));

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/controller/GetBookmarkRecipeController.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/controller/GetBookmarkRecipeController.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 
 import static com.greenbowl.greenbowlserver.common.utility.ApiConstant.ID_EXAMPLE;
 import static com.greenbowl.greenbowlserver.common.utility.ApiConstant.USER_ID;
-import static com.greenbowl.greenbowlserver.recipe.adapter.in.web.utility.ApiConstant.RECIPE_ID;
+import static com.greenbowl.greenbowlserver.recipe.adapter.in.web.utility.ApiConstant.RECIPE_ID_VALUE;
 import static org.springframework.http.HttpStatus.OK;
 
 @WebAdapter
@@ -54,7 +54,7 @@ public class GetBookmarkRecipeController {
     @ApiOperation(value = GET_BOOKMARKED_RECIPE, notes = GET_BOOKMARKED_RECIPE_DESCRIPTION)
     @GetMapping("/{id}")
     public ResponseEntity<GetDetailedRecipeResponse> getRecipe(
-            @ApiParam(value = RECIPE_ID, example = ID_EXAMPLE) @PathVariable(value = "id") String id) {
+            @ApiParam(value = RECIPE_ID_VALUE, example = ID_EXAMPLE) @PathVariable(value = "id") String id) {
         Recipe recipe = getRecipeUseCase.getRecipe(FormatConverter.parseToLong(id));
 
         return ResponseEntity.status(OK).body(GetDetailedRecipeResponse.from(recipe));

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/request/AddDetailedRecipeRequest.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/request/AddDetailedRecipeRequest.java
@@ -5,11 +5,11 @@ import lombok.Getter;
 
 import java.util.List;
 
+import static com.greenbowl.greenbowlserver.common.utility.ApiConstant.RECIPE_NAME_EXAMPLE;
+import static com.greenbowl.greenbowlserver.common.utility.ApiConstant.RECIPE_NAME_VALUE;
+
 @Getter
 public class AddDetailedRecipeRequest {
-    private static final String RECIPE_NAME_VALUE = "레시피 이름";
-    private static final String RECIPE_NAME_EXAMPLE = "된장찌개";
-
     private static final String IMAGE_URL_VALUE = "이미지 주소";
     private static final String IMAGE_URL_EXAMPLE
             = "https://ddipddipddip.s3.ap-northeast-2.amazonaws.com/images/default_food_image.jpg";

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/request/AddRecipeRequest.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/request/AddRecipeRequest.java
@@ -3,11 +3,11 @@ package com.greenbowl.greenbowlserver.recipe.adapter.in.web.request;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 
+import static com.greenbowl.greenbowlserver.common.utility.ApiConstant.RECIPE_NAME_EXAMPLE;
+import static com.greenbowl.greenbowlserver.common.utility.ApiConstant.RECIPE_NAME_VALUE;
+
 @Getter
 public class AddRecipeRequest {
-    private static final String RECIPE_NAME_VALUE = "레시피 이름";
-    private static final String RECIPE_NAME_EXAMPLE = "된장찌개";
-
     private static final String IMAGE_URL_VALUE = "이미지 주소";
     private static final String IMAGE_URL_EXAMPLE
             = "https://ddipddipddip.s3.ap-northeast-2.amazonaws.com/images/default_food_image.jpg";

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/utility/ApiConstant.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/utility/ApiConstant.java
@@ -1,5 +1,5 @@
 package com.greenbowl.greenbowlserver.recipe.adapter.in.web.utility;
 
 public class ApiConstant {
-    public static final String RECIPE_ID = "레시피 ID";
+    public static final String RECIPE_ID_VALUE = "레시피 ID";
 }

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/configuration/SwaggerConfig.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/configuration/SwaggerConfig.java
@@ -43,8 +43,8 @@ SwaggerConfig {
                 .build()
                 .apiInfo(apiInfo())
                 .securityContexts(Arrays.asList(securityContext()))
-                .securitySchemes(Arrays.asList(apiKey()));
-//                .pathMapping("/api/recipes");
+                .securitySchemes(Arrays.asList(apiKey()))
+                .pathMapping("/api/recipes");
     }
 
     private SecurityContext securityContext() {

--- a/recommendation-service/recommendation-adapters/build.gradle
+++ b/recommendation-service/recommendation-adapters/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
     implementation 'io.springfox:springfox-swagger-ui:3.0.0'
 
+    // streaming
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     // data
     implementation 'org.postgresql:postgresql:42.2.5'
     implementation 'com.h2database:h2:2.1.214'

--- a/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/configuration/WebConfig.java
+++ b/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/configuration/WebConfig.java
@@ -1,0 +1,21 @@
+package com.greenbowl.greenbowlserver.recommendation.adapter.in.web.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Value("${frontend.url}")
+    private String frontendUrl;
+
+    @Override
+    public void addCorsMappings(CorsRegistry corsRegistry) {
+        corsRegistry.addMapping("/**")
+                .allowedOriginPatterns(frontendUrl)
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(false);
+    }
+}

--- a/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/controller/RecommendLlmRecipeController.java
+++ b/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/controller/RecommendLlmRecipeController.java
@@ -1,0 +1,43 @@
+package com.greenbowl.greenbowlserver.recommendation.adapter.in.web.controller;
+
+import com.greenbowl.greenbowlserver.recommendation.adapter.in.web.mapper.RecommendationRequestToCommandMapper;
+import com.greenbowl.greenbowlserver.recommendation.adapter.in.web.request.RecipeOptionsRequest;
+import com.greenbowl.greenbowlserver.recommendation.adapter.in.web.response.ResponseGenerator;
+import com.greenbowl.greenbowlserver.recommendation.adapter.in.web.response.StreamingProcessor;
+import com.greenbowl.greenbowlserver.recommendation.port.in.usecase.RecommendLlmRecipeUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+@RestController
+@RequestMapping()
+@RequiredArgsConstructor
+public class RecommendLlmRecipeController {
+    private final RecommendLlmRecipeUseCase recommendLlmRecipeUseCase;
+
+    @GetMapping(value = "/recipes/sse", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<Flux<String>> requestRecipeLLM(
+            @RequestParam List<String> name,
+            @RequestParam List<String> usedIngredientNames,
+            @RequestParam List<String> usedIngredientWeights,
+            @RequestParam List<String> cookingTime,
+            @RequestParam List<String> calories
+    ) {
+        Flux<String> responseFlux = recommendLlmRecipeUseCase.recieveLLMRecommendedRecipe(
+                RecommendationRequestToCommandMapper.mapToCommand(
+                        RecipeOptionsRequest.of(name, usedIngredientNames, usedIngredientWeights, cookingTime, calories)
+                )
+        );
+
+        StreamingProcessor.proceedStreaming(responseFlux);
+
+        return ResponseGenerator.generateResponse(responseFlux);
+    }
+}

--- a/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/mapper/RecommendationRequestToCommandMapper.java
+++ b/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/mapper/RecommendationRequestToCommandMapper.java
@@ -1,0 +1,16 @@
+package com.greenbowl.greenbowlserver.recommendation.adapter.in.web.mapper;
+
+import com.greenbowl.greenbowlserver.recommendation.adapter.in.web.request.RecipeOptionsRequest;
+import com.greenbowl.greenbowlserver.recommendation.port.in.command.RecipeOptionsCommand;
+
+public class RecommendationRequestToCommandMapper {
+    public static RecipeOptionsCommand mapToCommand(RecipeOptionsRequest recipeOptionsRequest) {
+        return RecipeOptionsCommand.of(
+                recipeOptionsRequest.getName(),
+                recipeOptionsRequest.getUsedIngredientNames(),
+                recipeOptionsRequest.getUsedIngredientWeights(),
+                recipeOptionsRequest.getCookingTime(),
+                recipeOptionsRequest.getCalories()
+        );
+    }
+}

--- a/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/request/RecipeOptionsRequest.java
+++ b/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/request/RecipeOptionsRequest.java
@@ -1,0 +1,33 @@
+package com.greenbowl.greenbowlserver.recommendation.adapter.in.web.request;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RecipeOptionsRequest {
+    private List<String> name;
+    private List<String> usedIngredientNames;
+    private List<String> usedIngredientWeights;
+    private List<String> cookingTime;
+    private List<String> calories;
+
+
+    private RecipeOptionsRequest(
+            List<String> name, List<String> usedIngredientNames, List<String> usedIngredientWeights,
+            List<String> cookingTime, List<String> calories
+    ) {
+        this.name = name;
+        this.usedIngredientNames = usedIngredientNames;
+        this.usedIngredientWeights = usedIngredientWeights;
+        this.cookingTime = cookingTime;
+        this.calories = calories;
+    }
+
+    public static RecipeOptionsRequest of(
+            List<String> name, List<String> usedIngredientNames, List<String> usedIngredientWeights,
+            List<String> cookingTime, List<String> calories
+    ) {
+        return new RecipeOptionsRequest(name, usedIngredientNames, usedIngredientWeights, cookingTime, calories);
+    }
+}

--- a/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/response/ResponseGenerator.java
+++ b/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/response/ResponseGenerator.java
@@ -1,0 +1,13 @@
+package com.greenbowl.greenbowlserver.recommendation.adapter.in.web.response;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Flux;
+
+public class ResponseGenerator {
+    public static ResponseEntity<Flux<String>> generateResponse(Flux<String> responseFlux) {
+        return ResponseEntity.ok()
+                .contentType(MediaType.TEXT_PLAIN)
+                .body(responseFlux.flatMap(chunk -> Flux.just(chunk + "\n\n")));
+    }
+}

--- a/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/response/StreamingProcessor.java
+++ b/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/response/StreamingProcessor.java
@@ -1,0 +1,26 @@
+package com.greenbowl.greenbowlserver.recommendation.adapter.in.web.response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.greenbowl.greenbowlserver.common.utility.LogConstant.LOG_ERROR_MESSAGE;
+
+public class StreamingProcessor {
+    private static final Logger log = LoggerFactory.getLogger(StreamingProcessor.class);
+
+    public static void proceedStreaming(Flux<String> responseFlux) {
+        AtomicInteger counter = new AtomicInteger(0);
+        responseFlux.subscribe(
+                chunk -> {
+                    if (counter.incrementAndGet() % 10 == 0) {
+                        log.info("Received chunk: {}", chunk);
+                    }
+                },
+                error -> log.error(LOG_ERROR_MESSAGE, error.getMessage(), error),
+                () -> log.info("Streaming finished.")
+        );
+    }
+}

--- a/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/out/web/LLMRequest.java
+++ b/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/out/web/LLMRequest.java
@@ -1,0 +1,25 @@
+package com.greenbowl.greenbowlserver.recommendation.adapter.out.web;
+
+import com.greenbowl.greenbowlserver.recommendation.domain.RecipeOptions;
+import lombok.Getter;
+
+@Getter
+public class LLMRequest {
+    private String llm_type;
+    private String template;
+    private RecipeOptions options;
+    private String secret_key;
+
+    private LLMRequest(String llm_type, String template, RecipeOptions recipeOptions, String secret_key) {
+        this.llm_type = llm_type;
+        this.template = template;
+        options = recipeOptions;
+        this.secret_key = secret_key;
+    }
+
+    public static LLMRequest from(
+            String llm_type, String template, RecipeOptions recipeOptions, String secret_key
+    ) {
+        return new LLMRequest(llm_type, template, recipeOptions, secret_key);
+    }
+}

--- a/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/out/web/client/LLMStreamingClient.java
+++ b/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/out/web/client/LLMStreamingClient.java
@@ -1,0 +1,55 @@
+package com.greenbowl.greenbowlserver.recommendation.adapter.out.web.client;
+
+import com.greenbowl.greenbowlserver.recommendation.adapter.out.web.LLMRequest;
+import com.greenbowl.greenbowlserver.recommendation.domain.RecipeOptions;
+import com.greenbowl.greenbowlserver.recommendation.port.out.ReceiveLLMStreamingPort;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+
+@Component
+public class LLMStreamingClient implements ReceiveLLMStreamingPort {
+    private final WebClient webClient;
+    private static final String LLM_SERVER_URL = "https://hyobin-llm.duckdns.org";
+
+    public LLMStreamingClient() {
+        webClient = WebClient.create(LLM_SERVER_URL);
+    }
+
+    @Value("${llm.recipe.type}")
+    private String llmType;
+
+    @Value("${llm.recipe.template}")
+    private String template;
+
+    @Value("${llm.recipe.secret-key}")
+    private String secretKey;
+
+    @Value("${llm.server.endpoint.sse}")
+    private String sseRequestEndpoint;
+
+    @Override
+    public Flux<String> receiveLLMStreamingSSE(RecipeOptions recipeOptions) {
+        LLMRequest llmRequest = LLMRequest.from(llmType, template, recipeOptions, secretKey);
+
+        return webClientRequest(sseRequestEndpoint, llmRequest);
+    }
+
+    private Flux<String> webClientRequest(String requestEndpoint, LLMRequest llmRequest) {
+        return webClient.post()
+                .uri(requestEndpoint)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.TEXT_EVENT_STREAM)
+                .bodyValue(llmRequest)
+                .retrieve()
+                .bodyToFlux(DataBuffer.class)
+                .map(dataBuffer -> {
+                    byte[] bytes = new byte[dataBuffer.readableByteCount()];
+                    dataBuffer.read(bytes);
+                    return new String(bytes);
+                });
+    }
+}

--- a/recommendation-service/recommendation-adapters/src/main/resources/application.yml
+++ b/recommendation-service/recommendation-adapters/src/main/resources/application.yml
@@ -29,3 +29,15 @@ spring:
       matching-strategy: ANT_PATH_MATCHER
 logging:
   config: classpath:logback-spring.xml
+frontend:
+  url: ${FRONTEND_URL}
+llm:
+  server:
+    url: ${LLM_SERVER_API_URL}
+    endpoint:
+      streaming: ${LLM_SERVER_STREAMING_ENDPOINT}
+      sse: /${LLM_SERVER_SSE_ENDPOINT}
+  recipe:
+    type: ${LLM_TYPE}
+    template: ${LLM_TEMPLATE}
+    secret-key: ${SECRET_KEY}

--- a/recommendation-service/recommendation-application/build.gradle
+++ b/recommendation-service/recommendation-application/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     // data
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.12'
 
+    // streaming
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.8'
 }

--- a/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/port/in/command/RecipeOptionsCommand.java
+++ b/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/port/in/command/RecipeOptionsCommand.java
@@ -1,0 +1,35 @@
+package com.greenbowl.greenbowlserver.recommendation.port.in.command;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RecipeOptionsCommand {
+    private List<String> name;
+    private List<String> usedIngredientNames;
+    private List<String> usedIngredientWeights;
+    private List<String> cookingTime;
+    private List<String> calories;
+
+    @Builder
+    private RecipeOptionsCommand(
+            List<String> name, List<String> usedIngredientNames, List<String> usedIngredientWeights,
+            List<String> cookingTime, List<String> calories
+    ) {
+        this.name = name;
+        this.usedIngredientNames = usedIngredientNames;
+        this.usedIngredientWeights = usedIngredientWeights;
+        this.cookingTime = cookingTime;
+        this.calories = calories;
+    }
+
+    public static RecipeOptionsCommand of(
+            List<String> name, List<String> usedIngredientNames, List<String> usedIngredientWeights,
+            List<String> cookingTime, List<String> calories
+    ) {
+        return new RecipeOptionsCommand(name, usedIngredientNames, usedIngredientWeights, cookingTime, calories);
+    }
+}

--- a/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/port/in/mapper/RecommendationCommandToDomainMapper.java
+++ b/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/port/in/mapper/RecommendationCommandToDomainMapper.java
@@ -1,0 +1,16 @@
+package com.greenbowl.greenbowlserver.recommendation.port.in.mapper;
+
+import com.greenbowl.greenbowlserver.recommendation.domain.RecipeOptions;
+import com.greenbowl.greenbowlserver.recommendation.port.in.command.RecipeOptionsCommand;
+
+public class RecommendationCommandToDomainMapper {
+    public static RecipeOptions mapToDomainEntity(RecipeOptionsCommand recipeOptionsCommand) {
+        return RecipeOptions.of(
+                recipeOptionsCommand.getName(),
+                recipeOptionsCommand.getUsedIngredientNames(),
+                recipeOptionsCommand.getUsedIngredientWeights(),
+                recipeOptionsCommand.getCookingTime(),
+                recipeOptionsCommand.getCalories()
+        );
+    }
+}

--- a/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/port/in/usecase/RecommendLlmRecipeUseCase.java
+++ b/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/port/in/usecase/RecommendLlmRecipeUseCase.java
@@ -1,0 +1,9 @@
+package com.greenbowl.greenbowlserver.recommendation.port.in.usecase;
+
+
+import com.greenbowl.greenbowlserver.recommendation.port.in.command.RecipeOptionsCommand;
+import reactor.core.publisher.Flux;
+
+public interface RecommendLlmRecipeUseCase {
+    Flux<String> recieveLLMRecommendedRecipe(RecipeOptionsCommand recipeOptionsCommand);
+}

--- a/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/port/out/ReceiveLLMStreamingPort.java
+++ b/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/port/out/ReceiveLLMStreamingPort.java
@@ -1,0 +1,8 @@
+package com.greenbowl.greenbowlserver.recommendation.port.out;
+
+import com.greenbowl.greenbowlserver.recommendation.domain.RecipeOptions;
+import reactor.core.publisher.Flux;
+
+public interface ReceiveLLMStreamingPort {
+    Flux<String> receiveLLMStreamingSSE(RecipeOptions recipeOptions);
+}

--- a/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/service/RecommendLlmRecipeService.java
+++ b/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/service/RecommendLlmRecipeService.java
@@ -1,0 +1,29 @@
+package com.greenbowl.greenbowlserver.recommendation.service;
+
+import com.greenbowl.greenbowlserver.common.application.UseCase;
+import com.greenbowl.greenbowlserver.recommendation.port.in.command.RecipeOptionsCommand;
+import com.greenbowl.greenbowlserver.recommendation.port.in.mapper.RecommendationCommandToDomainMapper;
+import com.greenbowl.greenbowlserver.recommendation.port.in.usecase.RecommendLlmRecipeUseCase;
+import com.greenbowl.greenbowlserver.recommendation.port.out.ReceiveLLMStreamingPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Flux;
+
+import static org.springframework.transaction.annotation.Isolation.READ_UNCOMMITTED;
+
+@RequiredArgsConstructor
+@UseCase
+/**
+ * 중대한 무결성 이슈가 없고 실시간성이 중요한 LLM 스트리밍 기능의 성능 향상을 위해 Dirty Read 허용
+ */
+@Transactional(isolation = READ_UNCOMMITTED, readOnly = true, timeout = 20)
+public class RecommendLlmRecipeService implements RecommendLlmRecipeUseCase {
+    private final ReceiveLLMStreamingPort receiveLLMStreamingPort;
+
+    @Override
+    public Flux<String> recieveLLMRecommendedRecipe(RecipeOptionsCommand recipeOptionsCommand) {
+        return receiveLLMStreamingPort.receiveLLMStreamingSSE(
+                RecommendationCommandToDomainMapper.mapToDomainEntity(recipeOptionsCommand)
+        );
+    }
+}

--- a/recommendation-service/recommendation-domain/src/main/java/com/greenbowl/greenbowlserver/recommendation/configuration/CommonConfig.java
+++ b/recommendation-service/recommendation-domain/src/main/java/com/greenbowl/greenbowlserver/recommendation/configuration/CommonConfig.java
@@ -1,0 +1,11 @@
+package com.greenbowl.greenbowlserver.recommendation.configuration;
+
+import com.greenbowl.greenbowlserver.common.application.aop.LoggingAspect;
+import com.greenbowl.greenbowlserver.common.domain.excpeption.GlobalExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({LoggingAspect.class, GlobalExceptionHandler.class})
+public class CommonConfig {
+}

--- a/recommendation-service/recommendation-domain/src/main/java/com/greenbowl/greenbowlserver/recommendation/domain/RecipeOptions.java
+++ b/recommendation-service/recommendation-domain/src/main/java/com/greenbowl/greenbowlserver/recommendation/domain/RecipeOptions.java
@@ -1,0 +1,32 @@
+package com.greenbowl.greenbowlserver.recommendation.domain;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RecipeOptions {
+    private List<String> name;
+    private List<String> usedIngredientNames;
+    private List<String> usedIngredientWeights;
+    private List<String> cookingTime;
+    private List<String> calories;
+
+    private RecipeOptions(
+            List<String> name, List<String> usedIngredientNames, List<String> usedIngredientWeights,
+            List<String> cookingTime, List<String> calories
+    ) {
+        this.name = name;
+        this.usedIngredientNames = usedIngredientNames;
+        this.usedIngredientWeights = usedIngredientWeights;
+        this.cookingTime = cookingTime;
+        this.calories = calories;
+    }
+
+    public static RecipeOptions of(
+            List<String> name, List<String> usedIngredientNames, List<String> usedIngredientWeights,
+            List<String> cookingTime, List<String> calories
+    ) {
+        return new RecipeOptions(name, usedIngredientNames, usedIngredientWeights, cookingTime, calories);
+    }
+}


### PR DESCRIPTION
## resolve [TEAM15-245](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/milestones/tB2W9Yfc8yHIZetSLPnCI)
## resolve #16

## 작업내용
- 레시피 추천 Prompt 추가
- 레시피  추천 LLM 모델 설정 추가
- 요청 엔드포인트의 Secret Key 추가
- 기존에 구현한 LLM Streaming 서버로 Prompt 요청을 전송해 응답을 제공받는 비동기 클라이언트 추가
- 레시피 추천 요청 Prompt에 대한 SSE 방식의 Steraming 응답을 제공받을 수 있는 레시피 추천 엔드포인트 추가

## 배포
- [x] 성공
- [ ] 실패