### PR TITLE
[TEAM15-590] feat(recommendation): 클라이언트는 Recommendation Service에서 전송된 JSON 포맷의 상세 메뉴 정보 LLM 데이터를 수신할 수 있다 

### DIFF
--- a/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/controller/RecommendLlmMenuController.java
+++ b/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/controller/RecommendLlmMenuController.java
@@ -2,6 +2,7 @@ package com.greenbowl.greenbowlserver.recommendation.adapter.in.web.controller;
 
 import com.greenbowl.greenbowlserver.common.adapter.in.WebAdapter;
 import com.greenbowl.greenbowlserver.recommendation.adapter.in.web.mapper.RecommendationRequestToCommandMapper;
+import com.greenbowl.greenbowlserver.recommendation.adapter.in.web.request.DetailedMenuOptionsRequest;
 import com.greenbowl.greenbowlserver.recommendation.adapter.in.web.request.MenuOptionsRequest;
 import com.greenbowl.greenbowlserver.recommendation.port.in.usecase.RecommendLlmMenuUseCase;
 import io.swagger.annotations.ApiOperation;
@@ -49,6 +50,22 @@ public class RecommendLlmMenuController {
         String jsonResponse = recommendLlmMenuUseCase.receiveLLMRecommendedMenu(
                 RecommendationRequestToCommandMapper.mapToCommand(
                         MenuOptionsRequest.of(ingredients, cookingTimeLimit, cuisineType)
+                )
+        );
+
+        return ResponseEntity.status(OK).body(jsonResponse);
+    }
+
+    @GetMapping("/detailed")
+    public ResponseEntity<String> requestDetailedMenuLLM(
+            @RequestParam List<String> name,
+            @RequestParam List<String> availableIngredients,
+            @RequestParam List<String> cookingTime,
+            @RequestParam List<String> calories
+    ) {
+        String jsonResponse = recommendLlmMenuUseCase.receiveLLMRecommendedMenu(
+                RecommendationRequestToCommandMapper.mapToCommand(
+                        DetailedMenuOptionsRequest.of(name, availableIngredients, cookingTime, calories)
                 )
         );
 

--- a/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/controller/RecommendLlmRecipeController.java
+++ b/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/controller/RecommendLlmRecipeController.java
@@ -52,7 +52,7 @@ public class RecommendLlmRecipeController {
             @ApiParam(value = CALORIES_VALUE, defaultValue = CALORIES_EXAMPLE)
             @RequestParam List<String> calories
     ) {
-        Flux<String> responseFlux = recommendLlmRecipeUseCase.recieveLLMRecommendedRecipe(
+        Flux<String> responseFlux = recommendLlmRecipeUseCase.recieveLlmRecommendedRecipe(
                 RecommendationRequestToCommandMapper.mapToCommand(
                         RecipeOptionsRequest.of(name, usedIngredientNames, usedIngredientWeights, cookingTime, calories)
                 )

--- a/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/mapper/RecommendationRequestToCommandMapper.java
+++ b/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/mapper/RecommendationRequestToCommandMapper.java
@@ -1,7 +1,9 @@
 package com.greenbowl.greenbowlserver.recommendation.adapter.in.web.mapper;
 
+import com.greenbowl.greenbowlserver.recommendation.adapter.in.web.request.DetailedMenuOptionsRequest;
 import com.greenbowl.greenbowlserver.recommendation.adapter.in.web.request.MenuOptionsRequest;
 import com.greenbowl.greenbowlserver.recommendation.adapter.in.web.request.RecipeOptionsRequest;
+import com.greenbowl.greenbowlserver.recommendation.port.in.command.DetailedMenuOptionsCommand;
 import com.greenbowl.greenbowlserver.recommendation.port.in.command.MenuOptionsCommand;
 import com.greenbowl.greenbowlserver.recommendation.port.in.command.RecipeOptionsCommand;
 
@@ -21,6 +23,15 @@ public class RecommendationRequestToCommandMapper {
                 menuOptionsRequest.getIngredients(),
                 menuOptionsRequest.getCookingTimeLimit(),
                 menuOptionsRequest.getCuisineType()
+        );
+    }
+
+    public static DetailedMenuOptionsCommand mapToCommand(DetailedMenuOptionsRequest detailedMenuOptionsRequest) {
+        return DetailedMenuOptionsCommand.of(
+                detailedMenuOptionsRequest.getName(),
+                detailedMenuOptionsRequest.getAvailableIngredients(),
+                detailedMenuOptionsRequest.getCookingTime(),
+                detailedMenuOptionsRequest.getCalories()
         );
     }
 }

--- a/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/request/DetailedMenuOptionsRequest.java
+++ b/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/in/web/request/DetailedMenuOptionsRequest.java
@@ -1,0 +1,28 @@
+package com.greenbowl.greenbowlserver.recommendation.adapter.in.web.request;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class DetailedMenuOptionsRequest {
+    private List<String> name;
+    private List<String> availableIngredients;
+    private List<String> cookingTime;
+    private List<String> calories;
+
+    public DetailedMenuOptionsRequest(
+            List<String> name, List<String> availableIngredients, List<String> cookingTime, List<String> calories
+    ) {
+        this.name = name;
+        this.availableIngredients = availableIngredients;
+        this.cookingTime = cookingTime;
+        this.calories = calories;
+    }
+
+    public static DetailedMenuOptionsRequest of(
+            List<String> name, List<String> availableIngredients, List<String> cookingTime, List<String> calories
+    ) {
+        return new DetailedMenuOptionsRequest(name, availableIngredients, cookingTime, calories);
+    }
+}

--- a/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/out/web/client/LlmJsonClient.java
+++ b/recommendation-service/recommendation-adapters/src/main/java/com/greenbowl/greenbowlserver/recommendation/adapter/out/web/client/LlmJsonClient.java
@@ -30,6 +30,15 @@ public class LlmJsonClient implements ReceiveLlmJsonPort {
     @Value("${llm.menu.secret-key}")
     private String menuSecretKey;
 
+    @Value("${llm.detailed-menu.type}")
+    private String detailedMenuLlmType;
+
+    @Value("${llm.detailed-menu.template}")
+    private String detailedMenuTemplate;
+
+    @Value("${llm.detailed-menu.secret-key}")
+    private String detailedMenuSecretKey;
+
     @Value("${llm.server.endpoint.json}")
     private String requestEndpoint;
 
@@ -40,8 +49,11 @@ public class LlmJsonClient implements ReceiveLlmJsonPort {
         HttpHeaders headers = new HttpHeaders();
         headers.set(CONTENT_TYPE, APPLICATION_JSON);
 
-        String template = menusTemplate;
-        LlmRequest llmRequest = LlmRequest.from(menuLlmType, menuTemplate, options, menuSecretKey);
+        String llmType = chooseLlmType(isDetailed);
+        String template = chooseTemplate(isDetailed);
+        String secretKey = chooseSecretKey(isDetailed);
+
+        LlmRequest llmRequest = LlmRequest.from(llmType, template, options, secretKey);
 
         HttpEntity<LlmRequest> requestEntity = new HttpEntity<>(llmRequest, headers);
         ResponseEntity<String> responseEntity = restTemplate.exchange(
@@ -52,5 +64,29 @@ public class LlmJsonClient implements ReceiveLlmJsonPort {
         );
 
         return responseEntity.getBody();
+    }
+
+    private String chooseLlmType(boolean isDetailed) {
+        if (isDetailed) {
+            return detailedMenuLlmType;
+        }
+
+        return menuLlmType;
+    }
+
+    private String chooseTemplate(boolean isDetailed) {
+        if (isDetailed) {
+            return detailedMenuTemplate;
+        }
+
+        return menuTemplate;
+    }
+
+    private String chooseSecretKey(boolean isDetailed) {
+        if (isDetailed) {
+            return detailedMenuSecretKey;
+        }
+
+        return menuSecretKey;
     }
 }

--- a/recommendation-service/recommendation-adapters/src/main/resources/application.yml
+++ b/recommendation-service/recommendation-adapters/src/main/resources/application.yml
@@ -49,3 +49,7 @@ llm:
     type: ${MENUS_LLM_TYPE}
     template: ${MENUS_LLM_TEMPLATE}
     secret-key: ${MENUS_SECRET_KEY}
+  detailed-menu:
+    type: ${DETAILED_MENU_LLM_TYPE}
+    template: ${DETAILED_MENU_LLM_TEMPLATE}
+    secret-key: ${DETAILED_MENU_SECRET_KEY}

--- a/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/port/in/command/DetailedMenuOptionsCommand.java
+++ b/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/port/in/command/DetailedMenuOptionsCommand.java
@@ -1,0 +1,28 @@
+package com.greenbowl.greenbowlserver.recommendation.port.in.command;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class DetailedMenuOptionsCommand {
+    private List<String> name;
+    private List<String> availableIngredients;
+    private List<String> cookingTime;
+    private List<String> calories;
+
+    public DetailedMenuOptionsCommand(
+            List<String> name, List<String> availableIngredients, List<String> cookingTime, List<String> calories
+    ) {
+        this.name = name;
+        this.availableIngredients = availableIngredients;
+        this.cookingTime = cookingTime;
+        this.calories = calories;
+    }
+
+    public static DetailedMenuOptionsCommand of(
+            List<String> name, List<String> availableIngredients, List<String> cookingTime, List<String> calories
+    ) {
+        return new DetailedMenuOptionsCommand(name, availableIngredients, cookingTime, calories);
+    }
+}

--- a/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/port/in/mapper/RecommendationCommandToDomainMapper.java
+++ b/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/port/in/mapper/RecommendationCommandToDomainMapper.java
@@ -1,7 +1,9 @@
 package com.greenbowl.greenbowlserver.recommendation.port.in.mapper;
 
+import com.greenbowl.greenbowlserver.recommendation.domain.DetailedMenuOptions;
 import com.greenbowl.greenbowlserver.recommendation.domain.MenuOptions;
 import com.greenbowl.greenbowlserver.recommendation.domain.RecipeOptions;
+import com.greenbowl.greenbowlserver.recommendation.port.in.command.DetailedMenuOptionsCommand;
 import com.greenbowl.greenbowlserver.recommendation.port.in.command.MenuOptionsCommand;
 import com.greenbowl.greenbowlserver.recommendation.port.in.command.RecipeOptionsCommand;
 
@@ -21,6 +23,15 @@ public class RecommendationCommandToDomainMapper {
                 menuOptionsCommand.getIngredients(),
                 menuOptionsCommand.getCookingTimeLimit(),
                 menuOptionsCommand.getCookingTimeLimit()
+        );
+    }
+
+    public static DetailedMenuOptions mapToDomainEntity(DetailedMenuOptionsCommand detailedMenuOptionsCommand) {
+        return DetailedMenuOptions.of(
+                detailedMenuOptionsCommand.getName(),
+                detailedMenuOptionsCommand.getAvailableIngredients(),
+                detailedMenuOptionsCommand.getCookingTime(),
+                detailedMenuOptionsCommand.getCalories()
         );
     }
 }

--- a/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/port/in/usecase/RecommendLlmMenuUseCase.java
+++ b/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/port/in/usecase/RecommendLlmMenuUseCase.java
@@ -2,9 +2,12 @@ package com.greenbowl.greenbowlserver.recommendation.port.in.usecase;
 
 
 import com.greenbowl.greenbowlserver.common.application.UseCase;
+import com.greenbowl.greenbowlserver.recommendation.port.in.command.DetailedMenuOptionsCommand;
 import com.greenbowl.greenbowlserver.recommendation.port.in.command.MenuOptionsCommand;
 
 @UseCase
 public interface RecommendLlmMenuUseCase {
     String receiveLLMRecommendedMenu(MenuOptionsCommand menuOptionsCommand);
+
+    String receiveLLMRecommendedMenu(DetailedMenuOptionsCommand detailedMenuOptionsCommand);
 }

--- a/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/service/RecommendLlmMenuService.java
+++ b/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/service/RecommendLlmMenuService.java
@@ -1,6 +1,7 @@
 package com.greenbowl.greenbowlserver.recommendation.service;
 
 import com.greenbowl.greenbowlserver.common.application.UseCase;
+import com.greenbowl.greenbowlserver.recommendation.port.in.command.DetailedMenuOptionsCommand;
 import com.greenbowl.greenbowlserver.recommendation.port.in.command.MenuOptionsCommand;
 import com.greenbowl.greenbowlserver.recommendation.port.in.mapper.RecommendationCommandToDomainMapper;
 import com.greenbowl.greenbowlserver.recommendation.port.in.usecase.RecommendLlmMenuUseCase;
@@ -23,6 +24,13 @@ public class RecommendLlmMenuService implements RecommendLlmMenuUseCase {
     public String receiveLLMRecommendedMenu(MenuOptionsCommand menuOptionsCommand) {
         return receiveLlmJsonPort.receiveLlmResponse(
                 RecommendationCommandToDomainMapper.mapToDomainEntity(menuOptionsCommand), false
+        );
+    }
+
+    @Override
+    public String receiveLLMRecommendedMenu(DetailedMenuOptionsCommand detailedMenuOptionsCommand) {
+        return receiveLlmJsonPort.receiveLlmResponse(
+                RecommendationCommandToDomainMapper.mapToDomainEntity(detailedMenuOptionsCommand), true
         );
     }
 }

--- a/recommendation-service/recommendation-domain/src/main/java/com/greenbowl/greenbowlserver/recommendation/domain/DetailedMenuOptions.java
+++ b/recommendation-service/recommendation-domain/src/main/java/com/greenbowl/greenbowlserver/recommendation/domain/DetailedMenuOptions.java
@@ -1,0 +1,28 @@
+package com.greenbowl.greenbowlserver.recommendation.domain;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class DetailedMenuOptions {
+    private List<String> name;
+    private List<String> availableIngredients;
+    private List<String> cookingTime;
+    private List<String> calories;
+
+    public DetailedMenuOptions(
+            List<String> name, List<String> availableIngredients, List<String> cookingTime, List<String> calories
+    ) {
+        this.name = name;
+        this.availableIngredients = availableIngredients;
+        this.cookingTime = cookingTime;
+        this.calories = calories;
+    }
+
+    public static DetailedMenuOptions of(
+            List<String> name, List<String> availableIngredients, List<String> cookingTime, List<String> calories
+    ) {
+        return new DetailedMenuOptions(name, availableIngredients, cookingTime, calories);
+    }
+}


### PR DESCRIPTION
## resolve [TEAM15-590](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/milestones/UJ-Rk1eCpFaNOgAYryE3p)
## resolve #106

## 작업내용
- 상세 메뉴 정보 추천 Prompt 추가
- 기존에 구현한 LLM Streaming 서버로 Prompt 요청을 전송해 전체 상세 메뉴 응답을 제공받는 비동기 클라이언트 추가
- 레시피 추천 요청 Prompt에 대한 JSON 포맷의 응답을 제공받을 수 있는 상세 메뉴 추천 엔드포인트 추가

## 배포
- [ ] 성공
- [ ] 실패