### PR TITLE
[TEAM15-605] fix(recommendation): AI 서버로 조리 시간 제한이 중복 전송되는 문제 해결

### DIFF
--- a/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/port/in/mapper/RecommendationCommandToDomainMapper.java
+++ b/recommendation-service/recommendation-application/src/main/java/com/greenbowl/greenbowlserver/recommendation/port/in/mapper/RecommendationCommandToDomainMapper.java
@@ -22,7 +22,7 @@ public class RecommendationCommandToDomainMapper {
         return MenuOptions.of(
                 menuOptionsCommand.getIngredients(),
                 menuOptionsCommand.getCookingTimeLimit(),
-                menuOptionsCommand.getCookingTimeLimit()
+                menuOptionsCommand.getCuisineType()
         );
     }
 


### PR DESCRIPTION
## resolve [TEAM15-605](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/milestones/TSPlUHC-3p2TvGBraRusd)
## resolve #113

## 작업내용
- RecommendationCommandToDomainMapper 클래스의 중복된 cookingTimeLimit 변수 수정

## 배포
- [x] 성공
- [ ] 실패