### PR TITLE
[TEAM15-635] feat(recipe): 클라이언트는 북마크 데이터의 상세 레시피 정보 저장 여부를 확인할 수 있다

### DIFF
--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/response/GetDetailedRecipeResponse.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/in/web/response/GetDetailedRecipeResponse.java
@@ -1,5 +1,6 @@
 package com.greenbowl.greenbowlserver.recipe.adapter.in.web.response;
 
+import com.greenbowl.greenbowlserver.common.utility.FormatValidator;
 import com.greenbowl.greenbowlserver.recipe.domain.Recipe;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,6 +16,7 @@ public class GetDetailedRecipeResponse {
     private String imageUrl;
     private short cookingTime;
     private short calories;
+    private boolean isDetailed;
     private String oneLineIntroduction;
     private List<RecipeIngredientResponse> recipeIngredients;
     private String introduction;
@@ -25,7 +27,7 @@ public class GetDetailedRecipeResponse {
 
     @Builder
     private GetDetailedRecipeResponse(
-            Long id, String name, String imageUrl, short cookingTime, short calories,
+            Long id, String name, String imageUrl, short cookingTime, short calories, boolean isDetailed,
             String oneLineIntroduction, List<RecipeIngredientResponse> recipeIngredients,
             String introduction, NutritionResponse nutrition, LocalDateTime createdAt, LocalDateTime modifiedAt
     ) {
@@ -34,6 +36,7 @@ public class GetDetailedRecipeResponse {
         this.imageUrl = imageUrl;
         this.cookingTime = cookingTime;
         this.calories = calories;
+        this.isDetailed = isDetailed;
         this.oneLineIntroduction = oneLineIntroduction;
         this.recipeIngredients = recipeIngredients;
         this.introduction = introduction;
@@ -43,13 +46,16 @@ public class GetDetailedRecipeResponse {
     }
 
     public static GetDetailedRecipeResponse from(Recipe recipe) {
+        String oneLineIntroduction = recipe.getOneLineIntroduction();
+
         return GetDetailedRecipeResponse.builder()
                 .id(recipe.getId())
                 .name(recipe.getName())
                 .imageUrl(recipe.getImageUrl())
                 .cookingTime(recipe.getCookingTime())
                 .calories(recipe.getCalories())
-                .oneLineIntroduction(recipe.getOneLineIntroduction())
+                .isDetailed(FormatValidator.hasValue(oneLineIntroduction))
+                .oneLineIntroduction(oneLineIntroduction)
                 .recipeIngredients(
                         recipe.getRecipeIngredients()
                                 .stream()

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipePersistenceAdapter.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipePersistenceAdapter.java
@@ -38,7 +38,7 @@ public class RecipePersistenceAdapter implements SaveRecipePort, FindRecipePort,
 
     @Override
     public List<Recipe> findByName(String name) {
-        return recipeRepository.findByNameAndDeleteYnFalse(name)
+        return recipeRepository.findByNameAndDeleteYnFalseOrderByModifiedAtDesc(name)
                 .stream()
                 .map(RecipeJpaEntityToDomainMapper::mapToDomainEntity)
                 .collect(Collectors.toList());
@@ -57,7 +57,7 @@ public class RecipePersistenceAdapter implements SaveRecipePort, FindRecipePort,
 
     @Override
     public void deleteByName(String name) {
-        List<RecipeJpaEntity> recipeJpaEntities = recipeRepository.findByNameAndDeleteYnFalse(name);
+        List<RecipeJpaEntity> recipeJpaEntities = recipeRepository.findByNameAndDeleteYnFalseOrderByModifiedAtDesc(name);
         recipeJpaEntities.forEach(RecipeJpaEntity::delete);
     }
 }

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeRepository.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeRepository.java
@@ -9,7 +9,7 @@ public interface RecipeRepository extends JpaRepository<RecipeJpaEntity, Long> {
 
     boolean existsByIdAndDeleteYnFalse(Long id);
 
-    List<RecipeJpaEntity> findByNameAndDeleteYnFalse(String name);
+    List<RecipeJpaEntity> findByNameAndDeleteYnFalseOrderByModifiedAtDesc(String name);
 
     RecipeJpaEntity findByIdAndDeleteYnFalse(Long id);
 }

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/service/RemoveRecipeService.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/service/RemoveRecipeService.java
@@ -35,11 +35,6 @@ public class RemoveRecipeService implements RemoveRecipeUseCase {
     public void removeRecipe(String name) {
         List<Recipe> recipes = getRecipeUseCase.getRecipes(name);
 
-        if (recipes.size() == 1) {
-            deleteRecipePort.deleteById(recipes.get(0).getId());
-            return;
-        }
-
-        deleteRecipePort.deleteByName(name);
+        deleteRecipePort.deleteById(recipes.get(0).getId());
     }
 }

--- a/recommendation-service/recommendation-adapters/src/main/resources/application.yml
+++ b/recommendation-service/recommendation-adapters/src/main/resources/application.yml
@@ -7,9 +7,9 @@ spring:
     allow-bean-definition-overriding: true
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/greenbowl
-    username: postgresuser
-    password: postgrepassword
+    url: ${GREENBOWL_POSTGRES_URL}
+    username: ${GREENBOWL_POSTGRES_USERNAME}
+    password: ${GREENBOWL_POSTGRES_PASSWORD}
     hikari:
       minimum-idle: 5
       maximum-pool-size: 10


### PR DESCRIPTION
## resolve [TEAM15-635](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/milestones/js-1mK8p0nS2PJ0uOTyrW)
## resolve #139

## 작업내용
- 레시피 ID로 레시피 조회 시 상세 레시피 정보 저장 여부를 함께 전송하도록 변경

## 배포
- [x] 성공
- [ ] 실패