### PR TITLE
[TEAM15-674] fix(recipe): 북마크의 상세 정보 수정 시 재료가 중복 저장되는 문제 해결

### DIFF
--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeIngredientRepository.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeIngredientRepository.java
@@ -1,0 +1,6 @@
+package com.greenbowl.greenbowlserver.recipe.adapter.out.persistence.recipe;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecipeIngredientRepository extends JpaRepository<RecipeIngredientJpaEntity, Long> {
+}

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeJpaEntity.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipeJpaEntity.java
@@ -117,8 +117,8 @@ public class RecipeJpaEntity extends BaseGeneralEntity {
 
         List<RecipeIngredientJpaEntity> recipeIngredientJpaEntities
                 = generateIngredientEntities(recipe.getRecipeIngredients(), this);
-        this.recipeIngredients.clear();
         this.recipeIngredients = recipeIngredientJpaEntities;
+
         this.introduction = recipe.getIntroduction();
         this.nutrition = EmbeddableNutrition.from(recipe.getNutrition());
     }

--- a/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipePersistenceAdapter.java
+++ b/recipe-service/recipe-adapters/src/main/java/com/greenbowl/greenbowlserver/recipe/adapter/out/persistence/recipe/RecipePersistenceAdapter.java
@@ -18,10 +18,11 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class RecipePersistenceAdapter implements SaveRecipePort, FindRecipePort, UpdateRecipePort, DeleteRecipePort {
     private final RecipeRepository recipeRepository;
+    private final RecipeIngredientRepository recipeIngredientRepository;
 
     @Override
-    public void saveRecipe(Recipe recipe) {
-        recipeRepository.save(RecipeJpaEntity.from(recipe));
+    public Long saveRecipe(Recipe recipe) {
+        return recipeRepository.save(RecipeJpaEntity.from(recipe)).getId();
     }
 
     @Override
@@ -53,6 +54,7 @@ public class RecipePersistenceAdapter implements SaveRecipePort, FindRecipePort,
     @Override
     public void updateRecipe(Recipe recipe) {
         RecipeJpaEntity recipeJpaEntity = recipeRepository.findByIdAndDeleteYnFalse(recipe.getId());
+        recipeIngredientRepository.deleteAll(recipeJpaEntity.getRecipeIngredients());
         recipeJpaEntity.update(recipe);
     }
 

--- a/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/service/ModifyRecipeService.java
+++ b/recipe-service/recipe-application/src/main/java/com/greenbowl/greenbowlserver/recipe/service/ModifyRecipeService.java
@@ -12,6 +12,7 @@ import com.greenbowl.greenbowlserver.recipe.port.out.UpdateRecipePort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.greenbowl.greenbowlserver.common.domain.exception.ExceptionMessage.INCONSISTENT_USER_EXCEPTION_MESSAGE;
@@ -34,7 +35,7 @@ public class ModifyRecipeService implements ModifyRecipeUseCase {
         Long storedUserId = recipe.getUserId();
         Long receivedUserId = modifyRecipeCommand.getUserId();
 
-        if (storedUserId.equals(receivedUserId)) {
+        if (Objects.equals(storedUserId, receivedUserId)) {
             recipe.update(
                     modifyRecipeCommand.getOneLineIntroduction(),
                     modifyRecipeCommand.getIngredients()


### PR DESCRIPTION
## resolve [TEAM15-674](https://www.riido.io/DG11XV7pe-RiXFdLqau-e/teams/TEAM15/milestones/EMqZ1Efh8jEzM7Z6YHvMx)
## resolve #160

## 작업내용
- IngredientRepository 추가
- 북마크의 재료 수정 전에 기존 재료들을 IngredientRepository를 통해 삭제하도록 변경

## 배포
- [x] 성공
- [ ] 실패
